### PR TITLE
Swap width and height in getResolution

### DIFF
--- a/src/ly/count/android/api/Countly.java
+++ b/src/ly/count/android/api/Countly.java
@@ -323,7 +323,7 @@ class DeviceInfo
 		DisplayMetrics metrics = new DisplayMetrics();
 		display.getMetrics(metrics);
 
-		return metrics.heightPixels + "x" + metrics.widthPixels;
+		return metrics.widthPixels + "x" + metrics.heightPixels;
 	}
 	
 	public static String getCarrier(Context context)


### PR DESCRIPTION
Currently the Android SDK incorrectly sends the resolution as "Height"x"Width" but is displayed on the dashboard with the values swapped as "Width"x"Height" so it seems like devices are being used in landscape when portrait and vice versa.

The iOS SDK correctly sends "Width"x"Height".
