### PR TITLE
Handles exception when sim card is not present.

### DIFF
--- a/src/ly/count/android/api/Countly.java
+++ b/src/ly/count/android/api/Countly.java
@@ -315,7 +315,7 @@ class DeviceInfo {
 			npe.printStackTrace();
 			Log.e("Countly", "No carrier found");
 		}
-		return "No carrier";
+		return "";
 	}
 
 	public static String getLocale() {


### PR DESCRIPTION
This commit catches the NullPointer exception and logs in errors.
Return value will be "No carrier".

Fixes Issue #8
