### PR TITLE
Fix sql syntax error if json contains simple quote when recording an event

### DIFF
--- a/src/ly/count/android/api/Countly.java
+++ b/src/ly/count/android/api/Countly.java
@@ -643,7 +643,8 @@ class CountlyDB extends SQLiteOpenHelper {
 
 		SQLiteDatabase db = this.getWritableDatabase();
 
-		db.execSQL("INSERT OR REPLACE INTO " + EVENTS_TABLE_NAME + "(ID, EVENT) VALUES(1, '" + json.toString() + "');");
+		String query = "INSERT OR REPLACE INTO " + EVENTS_TABLE_NAME + "(ID, EVENT) VALUES(1, ?);";
+		db.rawQuery(query, new String[] { json.toString() });
 	}
 
 	public void clearEvents() {


### PR DESCRIPTION
Fix sql syntax error if json contains simple quote when recording an event.
Cf : http://stackoverflow.com/questions/1296180/android-quotes-within-an-sql-query-string
Fix issue : https://github.com/Countly/countly-sdk-android/issues/13
