### PR TITLE
Add InstanceIdListenerService to be able to update GCM tokens

### DIFF
--- a/sdk-messaging/src/main/AndroidManifest.xml
+++ b/sdk-messaging/src/main/AndroidManifest.xml
@@ -25,6 +25,14 @@
             <meta-data android:name="broadcast_action" android:value="ly.count.android.api.broadcast" />
         </service>
 
+        <service
+            android:name=".CountlyInstanceIdListenerService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.android.gms.iid.InstanceID"/>
+            </intent-filter>
+        </service>
+
         <service android:name="org.openudid.OpenUDID_service" android:exported="false">
             <intent-filter>
                 <action android:name="org.OpenUDID.GETUDID" />

--- a/sdk-messaging/src/main/java/ly/count/android/sdk/messaging/CountlyInstanceIdListenerService.java
+++ b/sdk-messaging/src/main/java/ly/count/android/sdk/messaging/CountlyInstanceIdListenerService.java
@@ -1,0 +1,31 @@
+package ly.count.android.sdk.messaging;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import com.google.android.gms.iid.InstanceIDListenerService;
+
+/**
+ * A service that handles Instance ID service notifications on token refresh.
+ *
+ * Any app using Instance ID or GCM must include a class extending InstanceIDListenerService and implement onTokenRefresh().
+ *
+ * Created by Lajos.Erdosi on 2016.07.05..
+ */
+public class CountlyInstanceIdListenerService extends InstanceIDListenerService {
+
+    /**
+     * Called when the system determines that the tokens need to be refreshed.
+     */
+    @Override
+    public void onTokenRefresh() {
+        // Get a reference to the application context.
+        Context context = getApplicationContext();
+        // Get the stored sender ID
+        String senderId = CountlyMessaging.getGCMPreferences(context).getString(CountlyMessaging.PROPERTY_REGISTRATION_SENDER, "");
+        // If there is no sender ID simply return
+        if (TextUtils.isEmpty(senderId)) return;
+        // Start registration to get the new token
+        CountlyMessaging.registerInBackground(context, senderId);
+    }
+}

--- a/sdk-messaging/src/main/java/ly/count/android/sdk/messaging/CountlyMessaging.java
+++ b/sdk-messaging/src/main/java/ly/count/android/sdk/messaging/CountlyMessaging.java
@@ -115,7 +115,7 @@ public class CountlyMessaging extends WakefulBroadcastReceiver {
     private static final String PREFERENCES_NAME = "ly.count.android.api.messaging";
     private static final String PROPERTY_REGISTRATION_ID = "ly.count.android.api.messaging.registration.id";
     private static final String PROPERTY_REGISTRATION_VERSION = "ly.count.android.api.messaging.version";
-    private static final String PROPERTY_REGISTRATION_SENDER = "ly.count.android.api.messaging.sender";
+    static final String PROPERTY_REGISTRATION_SENDER = "ly.count.android.api.messaging.sender";
     private static final String PROPERTY_APPLICATION_TITLE = "ly.count.android.api.messaging.app.title";
     private static final String PROPERTY_SERVER_URL = "ly.count.android.api.messaging.server.url";
     private static final String PROPERTY_APP_KEY = "ly.count.android.api.messaging.app.key";
@@ -205,7 +205,7 @@ public class CountlyMessaging extends WakefulBroadcastReceiver {
         }
     }
 
-    private static void registerInBackground(final Context context, final String sender) {
+    static void registerInBackground(final Context context, final String sender) {
         new AsyncTask<Void, Void, Void>() {
             @Override
             protected Void doInBackground(Void... params) {
@@ -214,7 +214,7 @@ public class CountlyMessaging extends WakefulBroadcastReceiver {
                     Countly.sharedInstance().onRegistrationId(registrationId);
                     storeRegistrationId(context, registrationId, sender);
                 } catch (IOException ex) {
-                    Log.e(TAG, "Failed to register for GCM identificator: " + ex.getMessage());
+                    Log.e(TAG, "Failed to register for GCM identification: " + ex.getMessage());
                 }
                 return null;
             }
@@ -233,7 +233,7 @@ public class CountlyMessaging extends WakefulBroadcastReceiver {
     }
 
 
-    private static SharedPreferences getGCMPreferences(Context context) {
+    static SharedPreferences getGCMPreferences(Context context) {
         return context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
     }
 


### PR DESCRIPTION
Currently Countly's SDK does not handle the case when GCM tokens are refreshed.
Applying this pull request it will make it.
