### PR TITLE
Allow Maps identical to iOS's NSDictionaries

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/Countly.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Countly.java
@@ -827,7 +827,7 @@ public class Countly {
      * @throws IllegalStateException if Countly SDK has not been initialized
      * @throws IllegalArgumentException if key is null or empty
      */
-    public void recordEvent(final String key, final Map<String, String> segmentation, final int count) {
+    public void recordEvent(final String key, final Map segmentation, final int count) {
         recordEvent(key, segmentation, count, 0);
     }
 
@@ -841,7 +841,7 @@ public class Countly {
      * @throws IllegalArgumentException if key is null or empty, count is less than 1, or if
      *                                  segmentation contains null or empty keys or values
      */
-    public synchronized void recordEvent(final String key, final Map<String, String> segmentation, final int count, final double sum) {
+    public synchronized void recordEvent(final String key, final Map segmentation, final int count, final double sum) {
         recordEvent(key, segmentation, count, sum, 0);
     }
 
@@ -856,8 +856,8 @@ public class Countly {
      * @throws IllegalArgumentException if key is null or empty, count is less than 1, or if
      *                                  segmentation contains null or empty keys or values
      */
-    public synchronized void recordEvent(final String key, final Map<String, String> segmentation, final int count, final double sum, final double dur){
-        recordEvent(key, segmentation, null, null, count, sum, 0);
+    public synchronized void recordEvent(final String key, final Map segmentation, final int count, final double sum, final double dur){
+        recordEvent(key, segmentation, null, null, count, sum, dur);
     }
 
     /**
@@ -871,7 +871,7 @@ public class Countly {
      * @throws IllegalArgumentException if key is null or empty, count is less than 1, or if
      *                                  segmentation contains null or empty keys or values
      */
-    public synchronized void recordEvent(final String key, final Map<String, String> segmentation, final Map<String, Integer> segmentationInt, final Map<String, Double> segmentationDouble, final int count, final double sum, final double dur) {
+    public synchronized void recordEvent(final String key, final Map segmentation, final Map<String, Integer> segmentationInt, final Map<String, Double> segmentationDouble, final int count, final double sum, final double dur) {
         if (!isInitialized()) {
             throw new IllegalStateException("Countly.sharedInstance().init must be called before recordEvent");
         }
@@ -887,11 +887,11 @@ public class Countly {
         }
 
         if (segmentation != null) {
-            for (String k : segmentation.keySet()) {
-                if (k == null || k.length() == 0) {
+            for (Object k : segmentation.keySet()) {
+                if (k == null || (!(k instanceof String) ||  ((String)k).length() == 0)) {
                     throw new IllegalArgumentException("Countly event segmentation key cannot be null or empty");
                 }
-                if (segmentation.get(k) == null || segmentation.get(k).length() == 0) {
+                if (segmentation.get(k) == null) {
                     throw new IllegalArgumentException("Countly event segmentation value cannot be null or empty");
                 }
             }

--- a/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
+++ b/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
@@ -269,7 +269,7 @@ public class CountlyStore {
      * @param sum sum associated with the custom event, if not used, pass zero.
      *            NaN and infinity values will be quietly ignored.
      */
-    public synchronized void addEvent(final String key, final Map<String, String> segmentation, final Map<String, Integer> segmentationInt, final Map<String, Double> segmentationDouble, final long timestamp, final int hour, final int dow, final int count, final double sum, final double dur) {
+    public synchronized void addEvent(final String key, final Map segmentation, final Map<String, Integer> segmentationInt, final Map<String, Double> segmentationDouble, final long timestamp, final int hour, final int dow, final int count, final double sum, final double dur) {
         final Event event = new Event();
         event.key = key;
         event.segmentation = segmentation;

--- a/sdk/src/main/java/ly/count/android/sdk/Event.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Event.java
@@ -23,11 +23,13 @@ package ly.count.android.sdk;
 
 import android.util.Log;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,7 +49,7 @@ class Event {
     private static final String HOUR = "hour";
 
     public String key;
-    public Map<String, String> segmentation;
+    public Map segmentation;
     public Map<String, Integer> segmentationInt;
     public Map<String, Double> segmentationDouble;
     public int count;
@@ -82,9 +84,7 @@ class Event {
 
             JSONObject jobj = new JSONObject();
             if (segmentation != null) {
-                for (Map.Entry<String, String> pair : segmentation.entrySet()) {
-                    jobj.put(pair.getKey(), pair.getValue());
-                }
+                jobj = JSONUtils.serializeMap(segmentation);
             }
 
             if(segmentationInt != null){

--- a/sdk/src/main/java/ly/count/android/sdk/EventQueue.java
+++ b/sdk/src/main/java/ly/count/android/sdk/EventQueue.java
@@ -93,7 +93,7 @@ public class EventQueue {
      *            NaN and infinity values will be quietly ignored.
      * @throws IllegalArgumentException if key is null or empty
      */
-    void recordEvent(final String key, final Map<String, String> segmentation, final Map<String, Integer> segmentationInt, final Map<String, Double> segmentationDouble, final int count, final double sum, final double dur) {
+    void recordEvent(final String key, final Map segmentation, final Map<String, Integer> segmentationInt, final Map<String, Double> segmentationDouble, final int count, final double sum, final double dur) {
         final long timestamp = Countly.currentTimestampMs();
         final int hour = Countly.currentHour();
         final int dow = Countly.currentDayOfWeek();

--- a/sdk/src/main/java/ly/count/android/sdk/JSONUtils.java
+++ b/sdk/src/main/java/ly/count/android/sdk/JSONUtils.java
@@ -1,0 +1,99 @@
+package ly.count.android.sdk;
+
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+
+class JSONUtils {
+
+    /**
+     * Serialize any container, which implements Map interface
+     * @param map Map, which should be serialized
+     * @return JSONObject for passed map
+     * @throws JSONException if unable to serialized passed map
+     */
+    static JSONObject serializeMap(Map map) throws JSONException {
+        JSONObject json = new JSONObject();
+        for (Object key : map.keySet()) {
+            if (!(key instanceof String)) {
+                throw new JSONException("Map key must be String, but found " + key.getClass().getName());
+            }
+            Object value = map.get(key);
+            if (value instanceof List) {
+                json.put((String)key, serializeList((List)value));
+            } else if (value.getClass().isArray()) {
+                json.put((String)key, serializeArray((Object[])value));
+            } else {
+                json.put((String)key, value);
+            }
+        }
+
+        return json;
+    }
+
+    /**
+     * Serialize any container, which implements List interface
+     * @param list List, which should be serialized
+     * @return JSONOArray for passed list
+     * @throws JSONException if unable to serialized passed list
+     */
+    static JSONArray serializeList(List list) throws JSONException {
+        JSONArray json = new JSONArray();
+        for (Object value : list) {
+            if (value instanceof Map) {
+                json.put(serializeMap((Map)value));
+            } else if (value instanceof List) {
+                json.put(serializeList((List)value));
+            } else if (value.getClass().isArray()) {
+                json.put(serializeArray((Object[])value));
+            } else {
+                json.put(value);
+            }
+        }
+
+        return json;
+    }
+
+    /**
+     * Serialize array
+     * @param array Array, which should be serialized
+     * @return JSONOArray for passed array
+     * @throws JSONException if unable to serialized passed array
+     */
+    static JSONArray serializeArray(Object[] array) throws JSONException {
+        JSONArray json = new JSONArray();
+        for (Object value : array) {
+            if (value instanceof Map) {
+                json.put(serializeMap((Map)value));
+            } else if (value instanceof List) {
+                json.put(serializeList((List)value));
+            } else if (value.getClass().isArray()) {
+                json.put(serializeArray((Object[])value));
+            } else if (value.getClass().isPrimitive()) {
+                switch (value.getClass().getName()) {
+                    case "int":
+                        json.put((int)value);
+                        break;
+                    case "long":
+                        json.put((long)value);
+                    case "double":
+                        json.put((double)value);
+                        break;
+                    case "boolean":
+                        json.put((boolean)value);
+                        break;
+                    default:
+                        throw new JSONException("Unable to handle provided value of primitive type " + value.getClass().getName());
+                }
+            } else {
+                json.put(value);
+            }
+        }
+
+        return json;
+    }
+}

--- a/sdk/src/main/java/ly/count/android/sdk/UserData.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UserData.java
@@ -7,8 +7,10 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -34,7 +36,7 @@ public class UserData {
     protected static String picture;
     private static String picturePath;
     protected static String gender;
-    protected static Map<String, String> custom;
+    protected static Map custom;
     protected static Map<String, JSONObject> customMods;
     protected static int byear = 0;
     private static boolean isSynced = true;
@@ -122,7 +124,7 @@ public class UserData {
      * @param data Map&lt;String, String&gt; with user data
      * @param customdata Map&lt;String, String&gt; with custom key values for this user
      */
-    public void setUserData(Map<String, String> data, Map<String, String> customdata) {
+    public void setUserData(Map<String, String> data, Map customdata) {
         UserData.setData(data);
         if(customdata != null)
             UserData.setCustomData(customdata);
@@ -306,9 +308,9 @@ public class UserData {
      * Sets user custom properties and values.
      * @param data Map with user custom key/values
      */
-    public static void setCustomData(Map<String, String> data){
+    public static void setCustomData(Map data){
         if(custom == null)
-            custom = new HashMap<>();
+            custom = new HashMap();
         custom.putAll(data);
         isSynced = false;
     }
@@ -318,9 +320,9 @@ public class UserData {
      * @param key String with key for the property
      * @param value String with value for the property
      */
-    public static void setCustomProperty(String key, String value){
+    public static void setCustomProperty(String key, Object value){
         if(custom == null)
-            custom = new HashMap<>();
+            custom = new HashMap();
         custom.put(key, value);
         isSynced = false;
     }
@@ -473,7 +475,7 @@ public class UserData {
 
             JSONObject ob;
             if(custom != null){
-                ob = new JSONObject(custom);
+                ob = JSONUtils.serializeMap(custom);
             }
             else{
                 ob = new JSONObject();


### PR DESCRIPTION
Current version is limited to Map<String, String>, while server can successfully receive and present data from Maps with identical data types as allowed in NSDictionaries.