### PR TITLE
track right stacktrace

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/Countly.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Countly.java
@@ -1421,10 +1421,13 @@ public class Countly {
                     Log.d(Countly.TAG, "Uncaught crash handler triggered");
                 }
                 if (getConsent(CountlyFeatureNames.crashes)) {
-
                     StringWriter sw = new StringWriter();
                     PrintWriter pw = new PrintWriter(sw);
-                    e.printStackTrace(pw);
+                    if (e.getCause() != null) {
+                        e.getCause().printStackTrace(pw);
+                    } else {
+                         e.printStackTrace(pw);
+                    }
 
                     //add other threads
                     if (moduleCrash.recordAllThreads) {


### PR DESCRIPTION
If an unexpected crash appear, you track this
![image](https://user-images.githubusercontent.com/3314607/67474233-6abd7e00-f654-11e9-9bf3-23f669122308.png)


but this is the stack trace to track, because it's the crash to track !
![image](https://user-images.githubusercontent.com/3314607/67474624-0ea72980-f655-11e9-8229-b2b6d4a6cd57.png)

