### PR TITLE
Past event recording

### DIFF
--- a/sdk/src/androidTest/java/ly/count/android/sdk/ConnectionQueueTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ConnectionQueueTests.java
@@ -24,15 +24,10 @@ package ly.count.android.sdk;
 import android.net.Uri;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -43,7 +38,6 @@ import static androidx.test.InstrumentationRegistry.getContext;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -296,7 +290,8 @@ public class ConnectionQueueTests {
         final Map<String, String> queryParams = parseQueryParams(queryStr);
         assertEquals(connQ.getAppKey(), queryParams.get("app_key"));
         assertNull(queryParams.get("device_id"));
-        final long curTimestamp = Countly.currentTimestampMs();
+        Event.Instant instant = Countly.currentInstant();
+        final long curTimestamp = instant.timestamp;
         final long curTimestampBelow = curTimestamp - timestampAllowance;
         final long curTimestampAbove = curTimestamp + timestampAllowance;
         final long actualTimestamp = Long.parseLong(queryParams.get("timestamp"));
@@ -318,7 +313,8 @@ public class ConnectionQueueTests {
         final Map<String, String> queryParams = parseQueryParams(queryStr);
         assertEquals(connQ.getAppKey(), queryParams.get("app_key"));
         assertNull(queryParams.get("device_id"));
-        final long curTimestamp = Countly.currentTimestampMs();
+        Event.Instant instant = Countly.currentInstant();
+        final long curTimestamp = instant.timestamp;
         final long curTimestampBelow = curTimestamp - timestampAllowance;
         final long curTimestampAbove = curTimestamp + timestampAllowance;
         final long actualTimestamp = Long.parseLong(queryParams.get("timestamp"));
@@ -340,7 +336,8 @@ public class ConnectionQueueTests {
         final Map<String, String> queryParams = parseQueryParams(queryStr);
         assertEquals(connQ.getAppKey(), queryParams.get("app_key"));
         assertNull(queryParams.get("device_id"));
-        final long curTimestamp = Countly.currentTimestampMs();
+        Event.Instant instant = Countly.currentInstant();
+        final long curTimestamp = instant.timestamp;
         final long curTimestampBelow = curTimestamp - timestampAllowance;
         final long curTimestampAbove = curTimestamp + timestampAllowance;
         final long actualTimestamp = Long.parseLong(queryParams.get("timestamp"));
@@ -373,7 +370,8 @@ public class ConnectionQueueTests {
         final Map<String, String> queryParams = parseQueryParams(queryStr);
         assertEquals(connQ.getAppKey(), queryParams.get("app_key"));
         assertNull(queryParams.get("device_id"));
-        final long curTimestamp = Countly.currentTimestampMs();
+        Event.Instant instant = Countly.currentInstant();
+        final long curTimestamp = instant.timestamp;
         final long curTimestampBelow = curTimestamp - timestampAllowance;
         final long curTimestampAbove = curTimestamp + timestampAllowance;
         final long actualTimestamp = Long.parseLong(queryParams.get("timestamp"));

--- a/sdk/src/androidTest/java/ly/count/android/sdk/CountlyStoreTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/CountlyStoreTests.java
@@ -39,7 +39,6 @@ import static androidx.test.InstrumentationRegistry.getContext;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -115,7 +114,8 @@ public class CountlyStoreTests {
     @Test
     public void testEvents_prefIsEmptyString() {
         // the following two calls will result in the pref being an empty string
-        store.addEvent("eventKey", null, null, null, Countly.currentTimestampMs(), Countly.currentHour(), Countly.currentDayOfWeek(), 1, 0.0d, 10.0d);
+        Event.Instant instant = Countly.currentInstant();
+        store.addEvent("eventKey", null, null, null, instant.timestamp, instant.hour, instant.dow, 1, 0.0d, 10.0d);
         store.removeEvents(store.eventsList());
         assertTrue(Arrays.equals(new String[0], store.events()));
     }
@@ -123,7 +123,8 @@ public class CountlyStoreTests {
     @Test
     public void testEvents_prefHasSingleValue() throws JSONException {
         final String eventKey = "eventKey";
-        store.addEvent(eventKey, null, null, null, Countly.currentTimestampMs(), Countly.currentHour(), Countly.currentDayOfWeek(), 1, 0.0d, 10.0d);
+        Event.Instant instant = Countly.currentInstant();
+        store.addEvent(eventKey, null, null, null, instant.timestamp, instant.hour, instant.dow, 1, 0.0d, 10.0d);
         final String[] eventJSONStrings = store.events();
         final JSONObject eventJSONObj = new JSONObject(eventJSONStrings[0]);
         assertEquals(eventKey, eventJSONObj.getString("key"));
@@ -134,8 +135,10 @@ public class CountlyStoreTests {
     public void testEvents_prefHasTwoValues() throws JSONException {
         final String eventKey1 = "eventKey1";
         final String eventKey2 = "eventKey2";
-        store.addEvent(eventKey1, null, null, null, Countly.currentTimestampMs(), Countly.currentHour(), Countly.currentDayOfWeek(), 1, 0.0d, 10.0d);
-        store.addEvent(eventKey2, null, null, null, Countly.currentTimestampMs(), Countly.currentHour(), Countly.currentDayOfWeek(), 1, 0.0d, 10.0d);
+        Event.Instant instant1 = Countly.currentInstant();
+        Event.Instant instant2 = Countly.currentInstant();
+        store.addEvent(eventKey1, null, null, null, instant1.timestamp, instant1.hour, instant1.dow, 1, 0.0d, 10.0d);
+        store.addEvent(eventKey2, null, null, null, instant2.timestamp + 1, instant2.hour, instant2.dow, 1, 0.0d, 10.0d);
         final String[] eventJSONStrs = store.events();
         final JSONObject eventJSONObj1 = new JSONObject(eventJSONStrs[0]);
         assertEquals(eventKey1, eventJSONObj1.getString("key"));
@@ -151,9 +154,10 @@ public class CountlyStoreTests {
 
     @Test
     public void testEventsList_singleEvent() {
+        Event.Instant instant = Countly.currentInstant();
         final Event event1 = new Event();
         event1.key = "eventKey1";
-        event1.timestamp = Countly.currentTimestampMs();
+        event1.timestamp = instant.timestamp;
         event1.count = 1;
         event1.dur = 10.0d;
         store.addEvent(event1.key, event1.segmentation, null, null, event1.timestamp, event1.hour, event1.dow, event1.count, event1.sum, event1.dur);
@@ -165,19 +169,20 @@ public class CountlyStoreTests {
 
     @Test
     public void testEventsList_sortingOfMultipleEvents() {
+        Event.Instant instant = Countly.currentInstant();
         final Event event1 = new Event();
         event1.key = "eventKey1";
-        event1.timestamp = Countly.currentTimestampMs();
+        event1.timestamp = instant.timestamp;
         event1.count = 1;
         event1.dur = 10.0d;
         final Event event2 = new Event();
         event2.key = "eventKey2";
-        event2.timestamp = Countly.currentTimestampMs() - 60000;
+        event2.timestamp = instant.timestamp - 60000;
         event2.count = 1;
         event2.dur = 10.0d;
         final Event event3 = new Event();
         event3.key = "eventKey3";
-        event3.timestamp = Countly.currentTimestampMs() - 30000;
+        event3.timestamp = instant.timestamp - 30000;
         event3.count = 1;
         event3.dur = 10.0d;
         store.addEvent(event1.key, event1.segmentation, null, null, event1.timestamp, event1.hour, event1.dow, event1.count, event1.sum, event1.dur);
@@ -193,17 +198,18 @@ public class CountlyStoreTests {
 
     @Test
     public void testEventsList_badJSON() {
+        Event.Instant instant = Countly.currentInstant();
         final Event event1 = new Event();
         event1.key = "eventKey1";
-        event1.timestamp = Countly.currentTimestampMs() - 60000;
-        event1.hour = Countly.currentHour();
-        event1.dow = Countly.currentDayOfWeek();
+        event1.timestamp = instant.timestamp - 60000;
+        event1.hour = instant.hour;
+        event1.dow = instant.dow;
         event1.count = 1;
         final Event event2 = new Event();
         event2.key = "eventKey2";
-        event2.timestamp = Countly.currentTimestampMs();
-        event2.hour = Countly.currentHour();
-        event2.dow = Countly.currentDayOfWeek();
+        event2.timestamp = instant.timestamp;
+        event2.hour = instant.hour;
+        event2.dow = instant.dow;
         event2.count = 1;
 
         final String joinedEventsWithBadJSON = event1.toJSON().toString() + ":::blah:::" + event2.toJSON().toString();
@@ -220,16 +226,17 @@ public class CountlyStoreTests {
     @Test
     public void testEventsList_EventFromJSONReturnsNull() {
         final Event event1 = new Event();
+        Event.Instant instant = Countly.currentInstant();
         event1.key = "eventKey1";
-        event1.timestamp = Countly.currentTimestampMs() - 60000;
-        event1.hour = Countly.currentHour();
-        event1.dow = Countly.currentDayOfWeek();
+        event1.timestamp = instant.timestamp - 60000;
+        event1.hour = instant.hour;
+        event1.dow = instant.dow;
         event1.count = 1;
         final Event event2 = new Event();
         event2.key = "eventKey2";
-        event2.timestamp = Countly.currentTimestampMs();
-        event2.hour = Countly.currentHour();
-        event2.dow = Countly.currentDayOfWeek();
+        event2.timestamp = instant.timestamp;
+        event2.hour = instant.hour;
+        event2.dow = instant.dow;
         event2.count = 1;
 
         final String joinedEventsWithBadJSON = event1.toJSON().toString() + ":::{\"key\":null}:::" + event2.toJSON().toString();
@@ -321,8 +328,9 @@ public class CountlyStoreTests {
     @Test
     public void testAddEvent() {
         final Event event1 = new Event();
+        Event.Instant instant = Countly.currentInstant();
         event1.key = "eventKey1";
-        event1.timestamp = Countly.currentTimestampMs() - 60000;
+        event1.timestamp = instant.timestamp - 60000;
         event1.count = 42;
         event1.sum = 3.2;
         event1.dur = 10.0d;
@@ -343,18 +351,19 @@ public class CountlyStoreTests {
     @Test
     public void testRemoveEvents() {
         final Event event1 = new Event();
+        Event.Instant instant = Countly.currentInstant();
         event1.key = "eventKey1";
-        event1.timestamp = Countly.currentTimestampMs() - 60000;
+        event1.timestamp = instant.timestamp - 60000;
         event1.count = 1;
         event1.dur = 10.0d;
         final Event event2 = new Event();
         event2.key = "eventKey2";
-        event2.timestamp = Countly.currentTimestampMs() - 30000;
+        event2.timestamp = instant.timestamp - 30000;
         event2.count = 1;
         event2.dur = 10.0d;
         final Event event3 = new Event();
         event3.key = "eventKey2";
-        event3.timestamp = Countly.currentTimestampMs();
+        event3.timestamp = instant.timestamp;
         event3.count = 1;
         event3.dur = 10.0d;
 
@@ -378,7 +387,8 @@ public class CountlyStoreTests {
         assertFalse(prefs.contains("EVENTS"));
         assertFalse(prefs.contains("CONNECTIONS"));
         store.addConnection("blah");
-        store.addEvent("eventKey", null, null, null, Countly.currentTimestampMs(), Countly.currentHour(), Countly.currentDayOfWeek(), 1, 0.0d, 10.0d);
+        Event.Instant instant = Countly.currentInstant();
+        store.addEvent("eventKey", null, null, null, instant.timestamp, instant.hour, instant.dow, 1, 0.0d, 10.0d);
         assertTrue(prefs.contains("EVENTS"));
         assertTrue(prefs.contains("CONNECTIONS"));
         store.clear();

--- a/sdk/src/androidTest/java/ly/count/android/sdk/CountlyTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/CountlyTests.java
@@ -21,7 +21,6 @@ THE SOFTWARE.
 */
 package ly.count.android.sdk;
 
-import android.content.Context;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -30,13 +29,10 @@ import org.junit.Before;
 import java.util.HashMap;
 
 import static androidx.test.InstrumentationRegistry.getContext;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -616,6 +612,22 @@ public class CountlyTests {
         } catch (IllegalArgumentException ignored) {
             // success
         }
+    }
+
+    @Test
+    public void testRecordPastEvent() {
+        Event event = new Event.Builder("foo").setInstant(Countly.currentInstant()).build();
+        EventQueue eventQueueMock = mock(EventQueue.class);
+        doNothing().when(eventQueueMock).recordPastEvent(event);
+        when(eventQueueMock.size()).thenReturn(1);
+        mCountly.setEventQueue(eventQueueMock);
+        mCountly.recordPastEvent(event);
+        verify(eventQueueMock).recordPastEvent(event);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRecordPastEvent_nullInput() {
+        mCountly.recordPastEvent(null);
     }
 
     //todo fix test, problem while mocking

--- a/sdk/src/androidTest/java/ly/count/android/sdk/EventTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/EventTests.java
@@ -51,6 +51,116 @@ public class EventTests {
     }
 
     @Test
+    public void testBuilder_minimum() {
+        String key = "foo";
+        Event event = new Event.Builder(key).build();
+        assertEquals(key, event.key);
+        assertEquals(1, event.count);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_nullKey() {
+        new Event.Builder(null);
+    }
+
+    @Test
+    public void testBuilder_reset() {
+        Event.Builder builder = new Event.Builder("foo").setCount(1);
+        Event beforeReset = builder.build();
+        builder.reset("bar");
+        Event afterReset = builder.setCount(2).build();
+        assertEquals(beforeReset.key, "foo");
+        assertEquals(beforeReset.count, 1);
+        assertEquals(afterReset.key, "bar");
+        assertEquals(afterReset.count, 2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_segmentation() {
+        assertNull(new Event.Builder("foo").build().segmentation);
+        Event event = new Event.Builder("foo").putSegmentationEntry("key", "value").build();
+        assertNotNull(event.segmentation);
+        assertEquals(event.segmentation.get("key"), "value");
+        assertEquals(event.segmentation.size(), 1);
+
+        Map<String, String> segs = new HashMap<String, String>() {{ put("key", "value"); }};
+        event = new Event.Builder("foo").setSegmentation(segs).build();
+        assertNotNull(event.segmentation);
+        assertEquals(event.segmentation.get("key"), "value");
+        assertEquals(event.segmentation.size(), 1);
+
+        new Event.Builder("foo").putSegmentationEntry(null, null).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_segmentationInt() {
+        assertNull(new Event.Builder("foo").build().segmentationInt);
+        Event event = new Event.Builder("foo").putSegmentationIntEntry("key", 1).build();
+        assertNotNull(event.segmentationInt);
+        assertEquals(event.segmentationInt.get("key").intValue(), 1);
+        assertEquals(event.segmentationInt.size(), 1);
+
+        Map<String, Integer> segs = new HashMap<String, Integer>() {{ put("key", 1); }};
+        event = new Event.Builder("foo").setSegmentationInt(segs).build();
+        assertNotNull(event.segmentationInt);
+        assertEquals(event.segmentationInt.get("key").intValue(), 1);
+        assertEquals(event.segmentationInt.size(), 1);
+
+        new Event.Builder("foo").putSegmentationEntry(null, null).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_segmentationDouble() {
+        assertNull(new Event.Builder("foo").build().segmentationDouble);
+        Event event = new Event.Builder("foo").putSegmentationDoubleEntry("key", 1d).build();
+        assertNotNull(event.segmentationDouble);
+        assertEquals(event.segmentationDouble.get("key"), 1d, 0.001);
+        assertEquals(event.segmentationDouble.size(), 1);
+
+        Map<String, Double> segs = new HashMap<String, Double>() {{ put("key", 1d); }};
+        event = new Event.Builder("foo").setSegmentationDouble(segs).build();
+        assertNotNull(event.segmentationDouble);
+        assertEquals(event.segmentationDouble.get("key"), 1d, 0.001);
+        assertEquals(event.segmentationDouble.size(), 1);
+
+        new Event.Builder("foo").putSegmentationEntry(null, null).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_count() {
+        Event event = new Event.Builder("foo").setCount(500).build();
+        assertEquals(event.count, 500);
+        new Event.Builder("foo").setCount(0);
+    }
+
+    @Test
+    public void testBuilder_sum() {
+        Event event = new Event.Builder("foo").setSum(500d).build();
+        assertEquals(event.sum, 500d, 0.0001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_dur() {
+        Event event = new Event.Builder("foo").setDur(500d).build();
+        assertEquals(event.dur, 500d, 0.001);
+        new Event.Builder("foo").setDur(-1d);
+    }
+
+    @Test
+    public void testBuilder_instant() {
+        Event.Instant instant = Countly.currentInstant();
+        Event event = new Event.Builder("foo").setInstant(instant).build();
+        assertEquals(event.timestamp, instant.timestamp);
+        assertEquals(event.dow, instant.dow);
+        assertEquals(event.hour, instant.hour);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInstant_invalidGet() {
+        Event.Instant.get(-1L);
+    }
+
+    @Test
     public void testEqualsAndHashCode() {
         final Event event1 = new Event();
         final Event event2 = new Event();

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
@@ -434,10 +434,11 @@ public class ConnectionQueue {
     }
 
     private String prepareCommonRequestData(){
+        final Event.Instant instant = Countly.currentInstant();
         return "app_key=" + appKey_
-                + "&timestamp=" + Countly.currentTimestampMs()
-                + "&hour=" + Countly.currentHour()
-                + "&dow=" + Countly.currentDayOfWeek()
+                + "&timestamp=" + instant.timestamp
+                + "&hour=" + instant.hour
+                + "&dow=" + instant.dow
                 + "&tz=" + DeviceInfo.getTimezoneOffset()
                 + "&sdk_version=" + Countly.COUNTLY_SDK_VERSION_STRING
                 + "&sdk_name=" + Countly.COUNTLY_SDK_NAME;

--- a/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
+++ b/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
@@ -173,7 +173,7 @@ public class CountlyStore {
      * Adds a custom event to the local store.
      * @param event event to be added to the local store, must not be null
      */
-    void addEvent(final Event event) {
+    public void addEvent(final Event event) {
         final List<Event> events = eventsList();
         if (events.size() < MAX_EVENTS) {
             events.add(event);

--- a/sdk/src/main/java/ly/count/android/sdk/EventQueue.java
+++ b/sdk/src/main/java/ly/count/android/sdk/EventQueue.java
@@ -52,7 +52,7 @@ public class EventQueue {
      * Returns the number of events in the local event queue.
      * @return the number of events in the local event queue
      */
-    int size() {
+    protected int size() {
         return countlyStore_.events().length;
    }
 
@@ -94,18 +94,20 @@ public class EventQueue {
      * @throws IllegalArgumentException if key is null or empty
      */
     void recordEvent(final String key, final Map<String, String> segmentation, final Map<String, Integer> segmentationInt, final Map<String, Double> segmentationDouble, final int count, final double sum, final double dur) {
-        final long timestamp = Countly.currentTimestampMs();
-        final int hour = Countly.currentHour();
-        final int dow = Countly.currentDayOfWeek();
-        countlyStore_.addEvent(key, segmentation, segmentationInt, segmentationDouble, timestamp, hour, dow, count, sum, dur);
+        final Event.Instant instant = Countly.currentInstant();
+        countlyStore_.addEvent(key, segmentation, segmentationInt, segmentationDouble, instant.timestamp, instant.hour, instant.dow, count, sum, dur);
     }
 
-    void recordEvent(final Event event) {
-        event.hour = Countly.currentHour();
-        event.dow = Countly.currentDayOfWeek();
+    void recordTimedEvent(final Event event) {
+        Event.Instant instant = Countly.currentInstant();
+        event.hour = instant.hour;
+        event.dow = instant.dow;
         countlyStore_.addEvent(event);
     }
 
+    protected void recordPastEvent(final Event event) {
+        countlyStore_.addEvent(event);
+    }
 
         // for unit tests
     CountlyStore getCountlyStore() {


### PR DESCRIPTION
## Summary:

Added the ability to record events that may have occurred in the past.

Currently, a timestamp is affixed to all events as they are recorded. However, there are scenarios in which a developer may want to record an event with a timestamp from the past.

Example:

* An analytics event occurs, but the user is on a metered data plan. The developer caches the metadata of the event with its timestamp, then records/reports it later when the user connects to an unmetered WiFi connection. 

## Additions / Changes:

* `Event` is now public, and it has been given a fluent builder: `Event.Builder`
* `Countly#recordPastEvent` has been added. When this method is used, the timestamp of the provided `Event` is not modified before it is sent to the Countly server.
* Removed `Countly#currentTimestampMs`, `#currentHour()`, and `#currentDayOfWeek()`, because having these as independent methods (which use different Calendar instances internally) make any joint usage prone to race conditions. Instead, `Event.Instant` has been added, which is just a 3-tuple of (timestampInMillis, hour, dow). `Event.Instant#get` gets an Instant for a given timestamp (can be from the past), and `Countly#currentInstant()` gets an Instant with uniqueness guaranteed by `TimeUniquesEnsurer`

Race condition explanation:

This code was previously in `EventQueue`:

```
final long timestamp = Countly.currentTimestampMs(); // from TimeUniquesEnsurer
final int hour = Countly.currentHour(); // new Calendar instance, no knowledge of timestamp
final int dow = Countly.currentDayOfWeek(); // new Calendar instance, no knowledge of timestamp
countlyStore_.addEvent(key, segmentation, segmentationInt, segmentationDouble, timestamp, hour, dow, count, sum, dur);
```


The potential for race condition is clear near midnight:

```
final long timestamp = Countly.currentTimestampMs(); // [Jan 1st 2020 23:59:59]
final int hour = Countly.currentHour(); // [Jan 1st 2020 23:59:59] hour is 23
final int dow = Countly.currentDayOfWeek(); // [Jan 2nd 2020 00:00:00] day is Thursday. Should be Wednesday!
countlyStore_.addEvent(key, segmentation, segmentationInt, segmentationDouble, timestamp, hour, dow, count, sum, dur);
```

The proposed version retrieves all 3 values on the same calendar set at the same time:

```
final Event.Instant instant = Countly.currentInstant();
countlyStore_.addEvent(key, segmentation, segmentationInt, segmentationDouble, instant.timestamp, instant.hour, instant.dow, count, sum, dur);
```