### PR TITLE
Null-guard ringer mode check

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/CrashDetails.java
+++ b/sdk/src/main/java/ly/count/android/sdk/CrashDetails.java
@@ -366,14 +366,18 @@ class CrashDetails {
      * Checks if device is muted.
      */
     static String isMuted(Context context) {
-        AudioManager audio = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-        switch( audio.getRingerMode() ){
-            case AudioManager.RINGER_MODE_SILENT:
-                return "true";
-            case AudioManager.RINGER_MODE_VIBRATE:
-                return "true";
-            default:
-                return "false";
+        try {
+            AudioManager audio = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+            switch (audio.getRingerMode()){
+                case AudioManager.RINGER_MODE_SILENT:
+                    // Fall-through
+                case AudioManager.RINGER_MODE_VIBRATE:
+                    return "true";
+                default:
+                    return "false";
+            }
+        } catch (Throwable thr) {
+            return "false";
         }
     }
 


### PR DESCRIPTION
## Summary:

On devices with incomplete Audio Service implementations, checking the device's ringer mode via `AudioManager#getRingerMode()` can throw a null pointer exception. This is due to carelessness in `getRingerMode()`'s implementation -- the audio service is retrieved, then `IAudioService#getRingerModeExternal()` is immediately called without guarding for a null service.

Source (from android.media.AudioManager.java):

```
    /**
     * Returns the current ringtone mode.
     *
     * @return The current ringtone mode, one of {@link #RINGER_MODE_NORMAL},
     *         {@link #RINGER_MODE_SILENT}, or {@link #RINGER_MODE_VIBRATE}.
     * @see #setRingerMode(int)
     */
    public int getRingerMode() {
        final IAudioService service = getService();
        try {
            return service.getRingerModeExternal();  // <-- service is null! NullPointerException
        } catch (RemoteException e) {
            throw e.rethrowFromSystemServer();
        }
    }
```

The below change protects against the bad implementation in the Android framework.