### PR TITLE
Fix typo while logging read battery level error

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/CrashDetails.java
+++ b/sdk/src/main/java/ly/count/android/sdk/CrashDetails.java
@@ -313,7 +313,7 @@ class CrashDetails {
         }
         catch(Exception e){
             if (Countly.sharedInstance().isLoggingEnabled()) {
-                Log.i(Countly.TAG, "Can't get batter level");
+                Log.i(Countly.TAG, "Can't get battery level");
             }
         }
 


### PR DESCRIPTION
## Summary:
There was a typo in the error message logged while reading battery level.
It was `batter`, it should say `battery`.

## Additions / Changes:
- Update message passed to `Log.i(String, String)`, pass `"Can't get battery level"` instead of `"Can't get batter level"`