### PR TITLE
Simultaneous view tracking, automatic Fragment tracking

### DIFF
--- a/app-native/src/main/AndroidManifest.xml
+++ b/app-native/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="ly.count.android.demo.crash">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app-native/src/main/java/ly/count/android/demo/crash/App.java
+++ b/app-native/src/main/java/ly/count/android/demo/crash/App.java
@@ -1,0 +1,22 @@
+package ly.count.android.demo.crash;
+
+import android.app.Application;
+import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.CountlyConfig;
+
+public class App extends Application {
+
+    final String COUNTLY_SERVER_URL = "https://try.count.ly";
+    final String COUNTLY_APP_KEY = "xxxxxxx";
+
+    @Override public void onCreate() {
+        super.onCreate();
+        Countly.applicationOnCreate();
+        CountlyConfig config = (new CountlyConfig(this, COUNTLY_APP_KEY, COUNTLY_SERVER_URL)).setDeviceId("4432")
+            .setLoggingEnabled(true)
+            .enableCrashReporting()
+            .setViewTracking(true)
+            .setRequiresConsent(false);
+        Countly.sharedInstance().init(config);
+    }
+}

--- a/app-native/src/main/java/ly/count/android/demo/crash/MainActivity.java
+++ b/app-native/src/main/java/ly/count/android/demo/crash/MainActivity.java
@@ -11,9 +11,10 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import ly.count.android.sdk.Countly;
 import ly.count.android.sdk.CountlyConfig;
-import ly.count.android.sdk.DeviceId;
+import ly.count.android.sdk.PersistentName;
 import ly.count.android.sdknative.CountlyNative;
 
+@PersistentName("MainActivity")
 public class MainActivity extends AppCompatActivity {
 
     private static String TAG = "CountlyDemoNative";
@@ -41,11 +42,9 @@ public class MainActivity extends AppCompatActivity {
         CountlyConfig config = (new CountlyConfig(appC, COUNTLY_APP_KEY, COUNTLY_SERVER_URL)).setDeviceId("4432")
                 .setLoggingEnabled(true)
                 .enableCrashReporting()
-                .setViewTracking(false)
+                .setViewTracking(true)
                 .setRequiresConsent(false);
         Countly.sharedInstance().init(config);
-
-        Countly.onCreate(this);
 
         // Example of a call to a native method
         TextView tv = findViewById(R.id.sampleText);
@@ -59,20 +58,6 @@ public class MainActivity extends AppCompatActivity {
                 testCrash();
             }
         });
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
     }
 
     // defined in native-lib.cpp

--- a/app-native/src/main/java/ly/count/android/demo/crash/MainActivity.java
+++ b/app-native/src/main/java/ly/count/android/demo/crash/MainActivity.java
@@ -1,6 +1,5 @@
 package ly.count.android.demo.crash;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -9,8 +8,6 @@ import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import ly.count.android.sdk.Countly;
-import ly.count.android.sdk.CountlyConfig;
 import ly.count.android.sdk.PersistentName;
 import ly.count.android.sdknative.CountlyNative;
 
@@ -18,9 +15,6 @@ import ly.count.android.sdknative.CountlyNative;
 public class MainActivity extends AppCompatActivity {
 
     private static String TAG = "CountlyDemoNative";
-
-    final String COUNTLY_SERVER_URL = "https://try.count.ly";
-    final String COUNTLY_APP_KEY = "xxxxxxx";
 
     // Used to load the 'native-lib' library on application startup.
     static {
@@ -35,16 +29,6 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
-        //init countly
-        Context appC = getApplicationContext();
-
-        CountlyConfig config = (new CountlyConfig(appC, COUNTLY_APP_KEY, COUNTLY_SERVER_URL)).setDeviceId("4432")
-                .setLoggingEnabled(true)
-                .enableCrashReporting()
-                .setViewTracking(true)
-                .setRequiresConsent(false);
-        Countly.sharedInstance().init(config);
 
         // Example of a call to a native method
         TextView tv = findViewById(R.id.sampleText);

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-messaging:18.0.0'
     implementation 'com.google.android.material:material:1.2.0-alpha01'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.annotation:annotation:1.1.0'
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleAPM.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleAPM.java
@@ -1,17 +1,19 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.appcompat.app.AppCompatActivity;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
 import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.PersistentName;
 
-public class ActivityExampleAPM extends Activity {
+@PersistentName("ActivityExampleAPM")
+public class ActivityExampleAPM extends AppCompatActivity {
 
     int[] successCodes = new int[]{100, 101, 200, 201, 202, 205, 300, 301, 303, 305};
     int[] failureCodes = new int[]{400, 402, 405, 408, 500, 501, 502, 505};
@@ -23,26 +25,8 @@ public class ActivityExampleAPM extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_apm);
-        Countly.onCreate(this);
 
-    }
 
-    @Override
-    public void onStart() {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop() {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 
     public void onClickStartTrace_1(View v) {

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleCrashReporting.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleCrashReporting.java
@@ -1,21 +1,21 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.appcompat.app.AppCompatActivity;
 import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.PersistentName;
 
 @SuppressWarnings("UnusedParameters")
-public class ActivityExampleCrashReporting extends Activity {
+@PersistentName("ActivityExampleCrashReporting")
+public class ActivityExampleCrashReporting extends AppCompatActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_crash_reporting);
-        Countly.onCreate(this);
-
     }
 
     @SuppressWarnings("unused")
@@ -115,25 +115,5 @@ public class ActivityExampleCrashReporting extends Activity {
         } else {
             Utility.AnotherRecursiveCall(3);
         }
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleCustomEvents.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleCustomEvents.java
@@ -1,25 +1,24 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.appcompat.app.AppCompatActivity;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
 import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.PersistentName;
 
 @SuppressWarnings("UnusedParameters")
-public class ActivityExampleCustomEvents extends Activity {
+@PersistentName("ActivityExampleCustomEvents")
+public class ActivityExampleCustomEvents extends AppCompatActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_custom_events);
-        Countly.onCreate(this);
-
     }
 
     public void onClickRecordEvent01(View v) {
@@ -92,25 +91,5 @@ public class ActivityExampleCustomEvents extends Activity {
         Map<String, Object> segmentation = new HashMap<>();
         segmentation.put("wall", "orange");
         Countly.sharedInstance().events().recordEvent("Custom event 9", segmentation, 4, 34);
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleDeepLinkA.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleDeepLinkA.java
@@ -1,20 +1,21 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 
+import androidx.appcompat.app.AppCompatActivity;
 import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.PersistentName;
 import ly.count.android.sdk.messaging.CountlyPush;
 
-public class ActivityExampleDeepLinkA extends Activity {
+@PersistentName("ActivityExampleDeepLinkA")
+public class ActivityExampleDeepLinkA extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_deep_link_a);
-        Countly.onCreate(this);
 
         Intent intent = getIntent();
         String action = intent.getAction();
@@ -27,25 +28,5 @@ public class ActivityExampleDeepLinkA extends Activity {
             message = bun.getParcelable(CountlyPush.EXTRA_MESSAGE);
         }
         int actionIndex = intent.getIntExtra(CountlyPush.EXTRA_ACTION_INDEX, -100);
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleDeepLinkB.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleDeepLinkB.java
@@ -1,20 +1,22 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.PersistentName;
 import ly.count.android.sdk.messaging.CountlyPush;
 
-public class ActivityExampleDeepLinkB extends Activity {
+@PersistentName("ActivityExampleDeepLinkB")
+public class ActivityExampleDeepLinkB extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_deep_link_b);
-        Countly.onCreate(this);
 
         Intent intent = getIntent();
         String action = intent.getAction();
@@ -27,25 +29,5 @@ public class ActivityExampleDeepLinkB extends Activity {
             message = bun.getParcelable(CountlyPush.EXTRA_MESSAGE);
         }
         int actionIndex = intent.getIntExtra(CountlyPush.EXTRA_ACTION_INDEX, -100);
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleDeepLinkB.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleDeepLinkB.java
@@ -1,13 +1,11 @@
 package ly.count.android.demo;
 
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import ly.count.android.sdk.Countly;
+
 import ly.count.android.sdk.PersistentName;
 import ly.count.android.sdk.messaging.CountlyPush;
 

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleDeviceId.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleDeviceId.java
@@ -1,10 +1,8 @@
 package ly.count.android.demo;
 
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import java.util.Random;
 

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleDeviceId.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleDeviceId.java
@@ -1,22 +1,24 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import java.util.Random;
 
 import ly.count.android.sdk.Countly;
 import ly.count.android.sdk.DeviceId;
+import ly.count.android.sdk.PersistentName;
 
-public class ActivityExampleDeviceId extends Activity {
+@PersistentName("ActivityExampleDeviceId")
+public class ActivityExampleDeviceId extends AppCompatActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_device_id);
-        Countly.onCreate(this);
     }
 
     public void onClickDeviceId01(View v) {
@@ -43,25 +45,4 @@ public class ActivityExampleDeviceId extends Activity {
         //set device id witho merge
         Countly.sharedInstance().changeDeviceId(null);
     }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
-    }
-
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleKotlin.kt
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleKotlin.kt
@@ -1,15 +1,22 @@
 package ly.count.android.demo
 
-import android.app.Activity
-import android.content.res.Configuration
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import ly.count.android.sdk.Countly
-import ly.count.android.sdk.ModuleAPM
+import ly.count.android.sdk.PersistentName
 
-class ActivityExampleKotlin : Activity() {
+/**
+ * Sample Activity in Kotlin
+ */
+@PersistentName("ActivityExampleKotlin")
+class ActivityExampleKotlin : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+  }
+
   override fun onStart() {
     super.onStart()
-    Countly.sharedInstance().onStart(this);
-
     Countly.sharedInstance().apm().startTrace("fff");
     Countly.sharedInstance().consent().checkAllConsent();
     Countly.sharedInstance().crashes().addCrashBreadcrumb("ddd");
@@ -18,16 +25,5 @@ class ActivityExampleKotlin : Activity() {
     Countly.sharedInstance().remoteConfig().allValues;
     Countly.sharedInstance().sessions().beginSession()
     Countly.sharedInstance().views().isAutomaticViewTrackingEnabled;
-
-  }
-
-  override fun onStop() {
-    Countly.sharedInstance().onStop();
-    super.onStop()
-  }
-
-  override fun onConfigurationChanged(newConfig: Configuration?) {
-    super.onConfigurationChanged(newConfig)
-    Countly.sharedInstance().onConfigurationChanged(newConfig);
   }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleMultiThreading.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleMultiThreading.java
@@ -1,37 +1,15 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
-import android.content.res.Configuration;
 import android.os.Bundle;
 
-import ly.count.android.sdk.Countly;
+import androidx.appcompat.app.AppCompatActivity;
+import ly.count.android.sdk.PersistentName;
 
-public class ActivityExampleMultiThreading extends Activity {
+@PersistentName("ActivityExampleMultiThreading")
+public class ActivityExampleMultiThreading extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_custom_events);
-        Countly.onCreate(this);
-
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleOthers.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleOthers.java
@@ -1,32 +1,21 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
-import android.widget.Toast;
 
-import java.util.Random;
-import java.util.regex.Pattern;
-
+import androidx.appcompat.app.AppCompatActivity;
 import ly.count.android.sdk.Countly;
 import ly.count.android.sdk.CountlyConfig;
-import ly.count.android.sdk.CountlyStarRating;
-import ly.count.android.sdk.CrashFilterCallback;
 import ly.count.android.sdk.DeviceId;
-import ly.count.android.sdk.RemoteConfig;
+import ly.count.android.sdk.PersistentName;
 
-@SuppressWarnings("UnusedParameters")
-public class ActivityExampleOthers extends Activity {
-    Activity activity;
-
+@PersistentName("ActivityExampleOthers")
+public class ActivityExampleOthers extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        activity = this;
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_others);
-        Countly.onCreate(this);
     }
 
     public void onClickViewOther05(View v) {
@@ -78,25 +67,5 @@ public class ActivityExampleOthers extends Activity {
                 .setRequiresConsent(false);
 
         Countly.sharedInstance().init(config);
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleRatings.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleRatings.java
@@ -1,11 +1,9 @@
 package ly.count.android.demo;
 
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import ly.count.android.sdk.Countly;
 import ly.count.android.sdk.FeedbackRatingCallback;

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleRatings.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleRatings.java
@@ -1,52 +1,36 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import ly.count.android.sdk.Countly;
-import ly.count.android.sdk.CountlyStarRating;
 import ly.count.android.sdk.FeedbackRatingCallback;
+import ly.count.android.sdk.PersistentName;
 import ly.count.android.sdk.StarRatingCallback;
 
-public class ActivityExampleRatings extends Activity {
-    Activity activity;
+@PersistentName("ActivityExampleRatings")
+public class ActivityExampleRatings extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_ratings);
-        Countly.onCreate(this);
-
-        activity = this;
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
     }
 
     public void onClickViewOther02(View v) {
         //show star rating
-        Countly.sharedInstance().ratings().showStarRating(activity, new StarRatingCallback() {
+        Countly.sharedInstance().ratings().showStarRating(this, new StarRatingCallback() {
             @Override
             public void onRate(int rating) {
-                Toast.makeText(activity, "onRate called with rating: " + rating, Toast.LENGTH_SHORT).show();
+                Toast.makeText(ActivityExampleRatings.this, "onRate called with rating: " + rating, Toast.LENGTH_SHORT).show();
             }
 
             @Override
             public void onDismiss() {
-                Toast.makeText(activity, "onDismiss called", Toast.LENGTH_SHORT).show();
+                Toast.makeText(ActivityExampleRatings.this, "onDismiss called", Toast.LENGTH_SHORT).show();
             }
         });
     }
@@ -54,11 +38,11 @@ public class ActivityExampleRatings extends Activity {
     public void onClickViewOther07(View v) {
         //show rating widget
         String widgetId = "xxxxx";
-        Countly.sharedInstance().ratings().showFeedbackPopup(widgetId, "Close", activity, new FeedbackRatingCallback() {
+        Countly.sharedInstance().ratings().showFeedbackPopup(widgetId, "Close", this, new FeedbackRatingCallback() {
             @Override
             public void callback(String error) {
                 if(error != null){
-                    Toast.makeText(activity, "Encountered error while showing feedback dialog: [" + error + "]", Toast.LENGTH_LONG).show();
+                    Toast.makeText(ActivityExampleRatings.this, "Encountered error while showing feedback dialog: [" + error + "]", Toast.LENGTH_LONG).show();
                 }
             }
         });
@@ -68,11 +52,5 @@ public class ActivityExampleRatings extends Activity {
         //record rating manually without showing any UI
         String widgetId = "5e4afa88967cc71e5b541f8c";
         Countly.sharedInstance().ratings().recordManualRating(widgetId, 3, "foo@bar.garr", "Ragnaros should watch out", true);
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleRemoteConfig.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleRemoteConfig.java
@@ -1,12 +1,14 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import ly.count.android.sdk.PersistentName;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -15,15 +17,13 @@ import java.util.Map;
 import ly.count.android.sdk.Countly;
 import ly.count.android.sdk.RemoteConfigCallback;
 
-public class ActivityExampleRemoteConfig extends Activity {
-    Activity activity;
+@PersistentName("ActivityExampleRemoteConfig")
+public class ActivityExampleRemoteConfig extends AppCompatActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        activity = this;
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_remote_config);
-        Countly.onCreate(this);
     }
 
     public void onClickRemoteConfigUpdate(View v) {
@@ -130,25 +130,5 @@ public class ActivityExampleRemoteConfig extends Activity {
         Toast t = Toast.makeText(getApplicationContext(), "Stored Remote Config Values: [" + printValues + "]", Toast.LENGTH_LONG);
         t.setGravity(Gravity.BOTTOM, 0,0);
         t.show();
-    }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleRemoteConfig.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleRemoteConfig.java
@@ -1,12 +1,10 @@
 package ly.count.android.demo;
 
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import ly.count.android.sdk.PersistentName;
 import org.json.JSONArray;

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleUserDetails.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleUserDetails.java
@@ -1,11 +1,8 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import java.util.HashMap;
 

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleUserDetails.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleUserDetails.java
@@ -5,19 +5,21 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import java.util.HashMap;
 
 import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.PersistentName;
 
 @SuppressWarnings("UnusedParameters")
-public class ActivityExampleUserDetails extends Activity {
+@PersistentName("ActivityExampleUserDetails")
+public class ActivityExampleUserDetails extends AppCompatActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_user_details);
-        Countly.onCreate(this);
-
     }
 
     public void onClickUserData01(View v) {
@@ -89,25 +91,6 @@ public class ActivityExampleUserDetails extends Activity {
         Countly.userData.pushUniqueValue("skill", "earth");
 
         Countly.userData.save();
-    }
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
     }
 }
 

--- a/app/src/main/java/ly/count/android/demo/ActivityExampleViewTracking.java
+++ b/app/src/main/java/ly/count/android/demo/ActivityExampleViewTracking.java
@@ -1,82 +1,90 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.FragmentTransaction;
 import java.util.HashMap;
 import java.util.Map;
 
 import ly.count.android.sdk.Countly;
+import ly.count.android.sdk.PersistentName;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings({"UnusedParameters", "unused"})
-public class ActivityExampleViewTracking extends Activity {
+@PersistentName("ActivityExampleViewTracking")
+public class ActivityExampleViewTracking extends AppCompatActivity {
+
+    // track views by a string name
+    private static final String STR_VIEW = "Awesome view";
+    private static final String STR_VIEW2 = "Better view";
+
+    // track views by their identity hashcode, not by a string name
+    // you can track multiple views with the same name with this approach
+    private static final Object OBJ_VIEW = new Object();
+    private static final Object OBJ_VIEW2 = new Object();
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_example_view_tracking);
-        Countly.onCreate(this);
-
+        newFragment(R.id.fragment_left, ContextCompat.getColor(this, R.color.colorPrimary));
+        newFragment(R.id.fragment_right, ContextCompat.getColor(this, R.color.colorPrimaryDark));
     }
 
-    public void onClickViewTrackingDisableAuto(View v) {
-        Countly.sharedInstance().setViewTracking(false);
-    }
-
-    public void onClickViewTrackingEnableAuto(View v) {
-        Countly.sharedInstance().setViewTracking(true);
-    }
-
-    public void onClickViewTracking03(View v) {
-
-    }
-
-    public void onClickViewTracking04(View v) {
-
-    }
-
-    public void onClickViewTracking05(View v) {
-
-    }
-
-    public void onClickViewTracking06(View v) {
-
+    public void onClickViewTrackingRecordViewById(View v) {
+        Countly.sharedInstance().views().recordView(OBJ_VIEW, null, "Best View");
     }
 
     public void onClickViewTrackingRecordView(View v) {
-        Countly.sharedInstance().recordView("Awesome view", null);
+        Countly.sharedInstance().views().recordView(STR_VIEW, null);
+    }
+
+    public void onClickViewTrackingEndById(View v) {
+        Countly.sharedInstance().views().endViewRecording(OBJ_VIEW);
+    }
+
+    public void onClickViewTrackingEnd(View v) {
+        Countly.sharedInstance().views().endViewRecording(STR_VIEW);
+    }
+
+    public void onClickViewTrackingRecordViewByIdWithSegmentation(View v) {
+        Map<String, Object> viewSegmentation = new HashMap<>();
+        viewSegmentation.put("Puppies", 789);
+        viewSegmentation.put("Black Holes", 5.56d);
+        viewSegmentation.put("Caribou", "White-tail");
+        Countly.sharedInstance().views().recordView(OBJ_VIEW2, viewSegmentation, "Best View");
+    }
+
+    public void onClickViewTrackingEndByIdWithSegmentation(View v) {
+        Countly.sharedInstance().views().endViewRecording(OBJ_VIEW2);
     }
 
     public void onClickViewTrackingRecordViewWithSegmentation(View v) {
         Map<String, Object> viewSegmentation = new HashMap<>();
-
         viewSegmentation.put("Cats", 123);
         viewSegmentation.put("Moons", 9.98d);
         viewSegmentation.put("Moose", "Deer");
-
-        Countly.sharedInstance().views().recordView("Better view", viewSegmentation);
+        Countly.sharedInstance().views().recordView(STR_VIEW2, viewSegmentation);
     }
 
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
+    public void onClickViewTrackingEndWithSegmentation(View v) {
+        Countly.sharedInstance().views().endViewRecording(STR_VIEW2);
     }
 
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
+    public void onFragmentClick(@NotNull View v) {
+        int containerId = v.getId();
+        ColorFragment f = (ColorFragment) getSupportFragmentManager().findFragmentById(containerId);
+        int primary = ContextCompat.getColor(this, R.color.colorPrimary);
+        int targetColor = (f != null && f.getColor() == primary) ? ContextCompat.getColor(this, R.color.colorPrimaryDark) : primary;
+        newFragment(containerId, targetColor);
     }
 
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
+    private void newFragment(int containerId, int color) {
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        ft.replace(containerId, ColorFragment.newInstance(color));
+        ft.commit();
     }
 }

--- a/app/src/main/java/ly/count/android/demo/App.java
+++ b/app/src/main/java/ly/count/android/demo/App.java
@@ -108,8 +108,6 @@ public class App extends Application {
                 + "PTJ7eeMmX9g/0h"
         };
 
-        Context appC = getApplicationContext();
-
         HashMap<String, String> customHeaderValues = new HashMap<>();
         customHeaderValues.put("foo", "bar");
 
@@ -123,7 +121,7 @@ public class App extends Application {
         metricOverride.put("_carrier", "BoneyK");
 
         Countly.sharedInstance().setLoggingEnabled(true);
-        CountlyConfig config = (new CountlyConfig(appC, COUNTLY_APP_KEY, COUNTLY_SERVER_URL)).setIdMode(DeviceId.Type.OPEN_UDID)
+        CountlyConfig config = (new CountlyConfig(this, COUNTLY_APP_KEY, COUNTLY_SERVER_URL)).setIdMode(DeviceId.Type.OPEN_UDID)
             //.enableTemporaryDeviceIdMode()
             .enableCrashReporting().setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true)
             .setRequiresConsent(true).setConsentEnabled(new String[] {

--- a/app/src/main/java/ly/count/android/demo/ColorFragment.kt
+++ b/app/src/main/java/ly/count/android/demo/ColorFragment.kt
@@ -1,0 +1,59 @@
+package ly.count.android.demo
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import ly.count.android.sdk.Countly
+import ly.count.android.sdk.PersistentName
+
+private const val ARG_COLOR = "color"
+
+/**
+ * A simple Fragment that fills itself with a single color. Used to demonstrate automatic fragment (view) tracking
+ */
+@PersistentName("ColorFragment")
+class ColorFragment : Fragment() {
+
+  var color: Int = 0
+    private set
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    color = arguments?.getInt(ARG_COLOR) ?: ContextCompat.getColor(context!!, R.color.colorPrimary)
+    // You can add segmentation to automatically recorded views!
+    val viewSegmentation = mapOf(
+        "Dogs" to 456,
+        "Suns" to 1.12,
+        "Elk" to "Reindeer"
+    )
+    // This segmentation will be included for this *instance* of this view's automatic recording!
+    Countly.sharedInstance().views().addViewSegmentation(this, viewSegmentation)
+  }
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    val view = inflater.inflate(R.layout.fragment_color, container, false)
+    view.findViewById<View>(R.id.root).setBackgroundColor(color)
+    return view
+  }
+
+  companion object {
+
+    /**
+     * Creates a new instance of [ColorFragment]
+     */
+    @JvmStatic
+    fun newInstance(color: Int) =
+      ColorFragment().apply {
+        arguments = Bundle().apply {
+          putInt(ARG_COLOR, color)
+        }
+      }
+  }
+}

--- a/app/src/main/java/ly/count/android/demo/MainActivity.java
+++ b/app/src/main/java/ly/count/android/demo/MainActivity.java
@@ -1,30 +1,25 @@
 package ly.count.android.demo;
 
-import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.Toast;
 
+import androidx.appcompat.app.AppCompatActivity;
 import java.util.HashMap;
 
 import ly.count.android.sdk.Countly;
-import ly.count.android.sdk.CountlyConfig;
-import ly.count.android.sdk.RemoteConfig;
-
+import ly.count.android.sdk.PersistentName;
 
 @SuppressWarnings("UnusedParameters")
-public class MainActivity extends Activity {
+@PersistentName("MainActivity")
+public class MainActivity extends AppCompatActivity {
     private String demoTag = "CountlyDemo";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
-        Countly.onCreate(this);
     }
 
     public void onClickButtonCustomEvents(View v) {
@@ -76,25 +71,4 @@ public class MainActivity extends Activity {
         Countly.sharedInstance().setCustomCrashSegments(data);
         Countly.sharedInstance().enableCrashReporting();
     }
-
-    @Override
-    public void onStart()
-    {
-        super.onStart();
-        Countly.sharedInstance().onStart(this);
-    }
-
-    @Override
-    public void onStop()
-    {
-        Countly.sharedInstance().onStop();
-        super.onStop();
-    }
-
-    @Override
-    public void onConfigurationChanged (Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        Countly.sharedInstance().onConfigurationChanged(newConfig);
-    }
-
 }

--- a/app/src/main/res/layout/activity_example_view_tracking.xml
+++ b/app/src/main/res/layout/activity_example_view_tracking.xml
@@ -10,59 +10,79 @@
               android:paddingBottom="@dimen/activity_vertical_margin" >
 
     <Button
-        android:id="@+id/button34"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:onClick="onClickViewTrackingDisableAuto"
-        android:text="turn off automatic view reporting" />
+        android:onClick="onClickViewTrackingRecordViewById"
+        android:text="record view by id" />
 
     <Button
-        android:id="@+id/button35"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:onClick="onClickViewTrackingEnableAuto"
-        android:text="turn on automatic view reporting" />
-
-    <Button
-        android:text="@string/present_modal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/button36"
-        android:enabled="false"/>
-
-    <Button
-        android:text="@string/navigation_controller_push_pop"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/button37"
-        android:enabled="false"/>
-
-    <Button
-        android:text="@string/add_exception"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/button38"
-        android:enabled="false"/>
-
-    <Button
-        android:text="@string/remove_exception"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/button39"
-        android:enabled="false"/>
+        android:onClick="onClickViewTrackingEndById"
+        android:text="end recording view by id" />
 
     <Button
         android:id="@+id/button40"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:onClick="onClickViewTrackingRecordView"
-        android:text="record view" />
+        android:text="record view by name" />
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:onClick="onClickViewTrackingEnd"
+        android:text="end recording view by name" />
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:onClick="onClickViewTrackingRecordViewByIdWithSegmentation"
+        android:text="by id with custom segmentation" />
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:onClick="onClickViewTrackingEndByIdWithSegmentation"
+        android:text="end by id with custom seg" />
 
     <Button
         android:id="@+id/button68"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:onClick="onClickViewTrackingRecordViewWithSegmentation"
-        android:text="record view with custom segmentation" />
+        android:text="by name with custom segmentation" />
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:onClick="onClickViewTrackingEndWithSegmentation"
+        android:text="end by name with custom seg" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Tap fragments below to see fragment tracking"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="36dp"
+        android:orientation="horizontal">
+
+        <FrameLayout
+            android:id="@+id/fragment_left"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="4"
+            android:onClick="onFragmentClick" />
+
+        <FrameLayout
+            android:id="@+id/fragment_right"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="4"
+            android:onClick="onFragmentClick" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_color.xml
+++ b/app/src/main/res/layout/fragment_color.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/root"
+        tools:context=".ColorFragment">
+</FrameLayout>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="AppTheme" parent="android:Theme.Material.Light">
-    </style>
-</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <color name="colorPrimary">#182a38</color>
+  <color name="colorPrimaryDark">#13b94d</color>
+  <color name="colorAccent">#FFFFFF</color>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,8 +1,11 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
     </style>
 
     <style name="AppTheme.NoActionBar">

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-core:${mockitoVersion}"
     androidTestImplementation "org.mockito:mockito-android:${mockitoVersion}"
 
-    //androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.7.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
 }
 
 publish {

--- a/sdk/src/androidTest/AndroidManifest.xml
+++ b/sdk/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="ly.count.android.sdk">
+    <application
+        android:name=".TestApplication"
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme">
+    </application>
+</manifest>

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ConnectionQueueTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ConnectionQueueTests.java
@@ -25,6 +25,7 @@ import android.app.Instrumentation;
 import android.net.Uri;
 import android.os.Bundle;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -63,8 +64,8 @@ public class ConnectionQueueTests {
     public void setUp() {
         Countly.sharedInstance().halt();
         Countly.sharedInstance().setLoggingEnabled(true);
-        freshConnQ = new ConnectionQueue();
-        Countly.sharedInstance().init(new CountlyConfig(getContext(), appKey, "http://countly.coupons.com"));
+        freshConnQ = new ConnectionQueue(Countly.sharedInstance());
+        Countly.sharedInstance().init(new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), appKey, "http://countly.coupons.com"));
         connQ = Countly.sharedInstance().connectionQueue_;
 
         //connQ = new ConnectionQueue();

--- a/sdk/src/androidTest/java/ly/count/android/sdk/CountlyConfigTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/CountlyConfigTests.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Assert;
@@ -27,7 +28,7 @@ public class CountlyConfigTests {
 
     @Test
     public void constructor(){
-        CountlyConfig config = new CountlyConfig(getContext(), "Som345345", "fsdf7349374");
+        CountlyConfig config = new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "Som345345", "fsdf7349374");
 
         assertDefaultValues(config, false);
     }
@@ -225,6 +226,7 @@ public class CountlyConfigTests {
             Assert.assertNull(config.context);
             Assert.assertNull(config.serverURL);
             Assert.assertNull(config.appKey);
+            Assert.assertNull(config.application);
         }
 
         Assert.assertNull(config.countlyStore);
@@ -266,7 +268,6 @@ public class CountlyConfigTests {
         Assert.assertFalse(config.starRatingDialogIsCancellable);
         Assert.assertFalse(config.starRatingShownAutomatically);
         Assert.assertFalse(config.starRatingDisableAskingForEachAppVersion);
-        Assert.assertNull(config.application);
         Assert.assertFalse(config.recordAppStartTime);
         Assert.assertFalse(config.disableLocation);
         Assert.assertNull(config.locationCountyCode);

--- a/sdk/src/androidTest/java/ly/count/android/sdk/CountlyTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/CountlyTests.java
@@ -21,8 +21,11 @@ THE SOFTWARE.
 */
 package ly.count.android.sdk;
 
+import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -39,9 +42,6 @@ import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.AdditionalMatchers;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 
 @RunWith(AndroidJUnit4.class)
 public class CountlyTests {
@@ -54,9 +54,8 @@ public class CountlyTests {
         countlyStore.clear();
 
         mUninitedCountly = new Countly();
-
         mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
     }
 
     @After
@@ -88,7 +87,7 @@ public class CountlyTests {
     @Test
     public void testInitWithNoDeviceID() {
         mUninitedCountly = spy(mUninitedCountly);
-        CountlyConfig cc = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly"));
+        CountlyConfig cc = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly"));
         mUninitedCountly.init(cc);
         verify(mUninitedCountly).init(cc);
     }
@@ -106,7 +105,7 @@ public class CountlyTests {
     @Test
     public void testInit_nullServerURL() {
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", null)).setDeviceId("1234"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", null)).setDeviceId("1234"));
             fail("expected null server URL to throw IllegalArgumentException");
         } catch (IllegalArgumentException ignored) {
             // success!
@@ -116,7 +115,7 @@ public class CountlyTests {
     @Test
     public void testInit_emptyServerURL() {
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "")).setDeviceId("1234"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "")).setDeviceId("1234"));
             fail("expected empty server URL to throw IllegalArgumentException");
         } catch (IllegalArgumentException ignored) {
             // success!
@@ -126,7 +125,7 @@ public class CountlyTests {
     @Test
     public void testInit_invalidServerURL() {
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "not-a-valid-server-url")).setDeviceId("1234"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "not-a-valid-server-url")).setDeviceId("1234"));
             fail("expected invalid server URL to throw IllegalArgumentException");
         } catch (IllegalArgumentException ignored) {
             // success!
@@ -136,7 +135,7 @@ public class CountlyTests {
     @Test
     public void testInit_nullAppKey() {
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), null, "http://test.count.ly")).setDeviceId("1234"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), null, "http://test.count.ly")).setDeviceId("1234"));
             fail("expected null app key to throw IllegalArgumentException");
         } catch (IllegalArgumentException ignored) {
             // success!
@@ -146,7 +145,7 @@ public class CountlyTests {
     @Test
     public void testInit_emptyAppKey() {
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "", "http://test.count.ly")).setDeviceId("1234"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "", "http://test.count.ly")).setDeviceId("1234"));
             fail("expected empty app key to throw IllegalArgumentException");
         } catch (IllegalArgumentException ignored) {
             // success!
@@ -156,13 +155,13 @@ public class CountlyTests {
     @Test
     public void testInit_nullDeviceID() {
         // null device ID is okay because it tells Countly to use OpenUDID
-       mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId(null));
+       mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId(null));
     }
 
     @Test
     public void testInit_emptyDeviceID() {
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId(""));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId(""));
             fail("expected empty device ID to throw IllegalArgumentException");
         } catch (IllegalArgumentException ignored) {
             // success!
@@ -175,7 +174,7 @@ public class CountlyTests {
         final String appKey = "appkey";
         final String serverURL = "http://test.count.ly";
 
-        mUninitedCountly.init((new CountlyConfig(getContext(), appKey, serverURL)).setDeviceId(deviceID));
+        mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), appKey, serverURL)).setDeviceId(deviceID));
         final EventQueue expectedEventQueue = mUninitedCountly.getEventQueue();
         final ConnectionQueue expectedConnectionQueue = mUninitedCountly.getConnectionQueue();
         final CountlyStore expectedCountlyStore = expectedConnectionQueue.getCountlyStore();
@@ -184,7 +183,7 @@ public class CountlyTests {
         assertNotNull(expectedCountlyStore);
 
         // second call with same params should succeed, no exception thrown
-        mUninitedCountly.init((new CountlyConfig(getContext(), appKey, serverURL)).setDeviceId(deviceID));
+        mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), appKey, serverURL)).setDeviceId(deviceID));
 
         assertSame(expectedEventQueue, mUninitedCountly.getEventQueue());
         assertSame(expectedConnectionQueue, mUninitedCountly.getConnectionQueue());
@@ -196,21 +195,10 @@ public class CountlyTests {
     }
 
     @Test
-    public void testInit_twiceWithDifferentContext() {
-        mUninitedCountly.init(getContext(), "http://test.count.ly", "appkey", "1234");
-        // changing context is okay since SharedPrefs are global singletons
-
-        Context mContext = mock(Context.class);
-        when(mContext.getCacheDir()).thenReturn(getContext().getCacheDir());
-
-        mUninitedCountly.init(mContext, "http://test.count.ly", "appkey", "1234");
-    }
-
-    @Test
     public void testInit_twiceWithDifferentServerURL() {
-        mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "http://test1.count.ly")).setDeviceId("1234"));
+        mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test1.count.ly")).setDeviceId("1234"));
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "http://test2.count.ly")).setDeviceId("1234"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test2.count.ly")).setDeviceId("1234"));
             fail("expected IllegalStateException to be thrown when calling init a second time with different serverURL");
         }
         catch (IllegalStateException ignored) {
@@ -220,9 +208,9 @@ public class CountlyTests {
 
     @Test
     public void testInit_twiceWithDifferentAppKey() {
-        mUninitedCountly.init((new CountlyConfig(getContext(), "appkey1", "http://test.count.ly")).setDeviceId("1234"));
+        mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey1", "http://test.count.ly")).setDeviceId("1234"));
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "appkey2", "http://test.count.ly")).setDeviceId("1234"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey2", "http://test.count.ly")).setDeviceId("1234"));
             fail("expected IllegalStateException to be thrown when calling init a second time with different app key");
         }
         catch (IllegalStateException ignored) {
@@ -232,9 +220,9 @@ public class CountlyTests {
 
     @Test
     public void testInit_twiceWithDifferentDeviceID() {
-        mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234"));
+        mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234"));
         try {
-            mUninitedCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("4321"));
+            mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("4321"));
             fail("expected IllegalStateException to be thrown when calling init a second time with different device ID");
         }
         catch (IllegalStateException ignored) {
@@ -248,7 +236,7 @@ public class CountlyTests {
         final String appKey = "appkey";
         final String serverURL = "http://test.count.ly";
 
-        mUninitedCountly.init((new CountlyConfig(getContext(), appKey, serverURL)).setDeviceId(deviceID));
+        mUninitedCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), appKey, serverURL)).setDeviceId(deviceID));
 
         assertSame(getContext().getApplicationContext(), mUninitedCountly.getConnectionQueue().getContext());
         assertEquals(serverURL, mUninitedCountly.getConnectionQueue().getServerURL());
@@ -274,13 +262,14 @@ public class CountlyTests {
 
     @Test
     public void testHalt() {
+        Activity activity = mock(Activity.class);
         CountlyStore mockCountlyStore = mock(CountlyStore.class);
 
         when(mockCountlyStore.getLocationDisabled()).thenReturn(true);
         when(mockCountlyStore.getCachedAdvertisingId()).thenReturn("");
 
         mCountly.getConnectionQueue().setCountlyStore(mockCountlyStore);
-        mCountly.onStart(null);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         assertTrue(0 != mCountly.getPrevSessionDurationStartTime());
         assertTrue(0 != mCountly.getActivityCount());
         assertNotNull(mCountly.getEventQueue());
@@ -321,23 +310,17 @@ public class CountlyTests {
         assertEquals(0, mCountly.modules.size());
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void testOnStart_initNotCalled() {
-        try {
-            mUninitedCountly.onStart(null);
-            fail("expected calling onStart before init to throw IllegalStateException");
-        } catch (IllegalStateException ignored) {
-            // success!
-        }
+        mUninitedCountly.activityLifecycleCallbacks_.onActivityStarted(mock(Activity.class));
     }
 
     @Test
     public void testOnStart_firstCall() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
-
-        mCountly.onStart(null);
-
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         assertEquals(1, mCountly.getActivityCount());
         final long prevSessionDurationStartTime = mCountly.getPrevSessionDurationStartTime();
         assertTrue(prevSessionDurationStartTime > 0);
@@ -347,45 +330,37 @@ public class CountlyTests {
 
     @Test
     public void testOnStart_subsequentCall() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
 
-        mCountly.onStart(null); // first call to onStart
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         final long prevSessionDurationStartTime = mCountly.getPrevSessionDurationStartTime();
-        mCountly.onStart(null); // second call to onStart
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
 
         assertEquals(2, mCountly.getActivityCount());
         assertEquals(prevSessionDurationStartTime, mCountly.getPrevSessionDurationStartTime());
         verify(mockConnectionQueue).beginSession();
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void testOnStop_initNotCalled() {
-        try {
-            mUninitedCountly.onStop();
-            fail("expected calling onStop before init to throw IllegalStateException");
-        } catch (IllegalStateException ignored) {
-            // success!
-        }
+        mUninitedCountly.activityLifecycleCallbacks_.onActivityStopped(mock(Activity.class));
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void testOnStop_unbalanced() {
-        try {
-            mCountly.onStop();
-            fail("expected calling onStop before init to throw IllegalStateException");
-        } catch (IllegalStateException ignored) {
-            // success!
-        }
+        mCountly.activityLifecycleCallbacks_.onActivityStopped(mock(Activity.class));
     }
 
     @Test
     public void testOnStop_reallyStopping_emptyEventQueue() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
 
-        mCountly.onStart(null);
-        mCountly.onStop();
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
+        mCountly.activityLifecycleCallbacks_.onActivityStopped(activity);
 
         assertEquals(0, mCountly.getActivityCount());
         assertEquals(0, mCountly.getPrevSessionDurationStartTime());
@@ -395,6 +370,7 @@ public class CountlyTests {
 
     @Test
     public void testOnStop_reallyStopping_nonEmptyEventQueue() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
 
@@ -405,8 +381,8 @@ public class CountlyTests {
         final String eventStr = "blahblahblahblah";
         when(mockEventQueue.events()).thenReturn(eventStr);
 
-        mCountly.onStart(null);
-        mCountly.onStop();
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
+        mCountly.activityLifecycleCallbacks_.onActivityStopped(activity);
 
         assertEquals(0, mCountly.getActivityCount());
         assertEquals(0, mCountly.getPrevSessionDurationStartTime());
@@ -416,13 +392,14 @@ public class CountlyTests {
 
     @Test
     public void testOnStop_notStopping() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
 
-        mCountly.onStart(null);
-        mCountly.onStart(null);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         final long prevSessionDurationStartTime = mCountly.getPrevSessionDurationStartTime();
-        mCountly.onStop();
+        mCountly.activityLifecycleCallbacks_.onActivityStopped(activity);
 
         assertEquals(1, mCountly.getActivityCount());
         assertEquals(prevSessionDurationStartTime, mCountly.getPrevSessionDurationStartTime());
@@ -725,6 +702,7 @@ public class CountlyTests {
 
     @Test
     public void testOnTimer_activeSession_emptyEventQueue() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
 
@@ -732,7 +710,7 @@ public class CountlyTests {
         when(mockEventQueue.size()).thenReturn(0);
         mCountly.setEventQueue(mockEventQueue);
 
-        mCountly.onStart(null);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         mCountly.onTimer();
 
         verify(mockConnectionQueue).updateSession(0);
@@ -741,6 +719,7 @@ public class CountlyTests {
 
     @Test
     public void testOnTimer_activeSession_nonEmptyEventQueue() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
 
@@ -750,7 +729,7 @@ public class CountlyTests {
         when(mockEventQueue.events()).thenReturn(eventData);
         mCountly.setEventQueue(mockEventQueue);
 
-        mCountly.onStart(null);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         mCountly.onTimer();
 
         verify(mockConnectionQueue).updateSession(0);
@@ -759,6 +738,7 @@ public class CountlyTests {
 
     @Test
     public void testOnTimer_activeSession_emptyEventQueue_sessionTimeUpdatesDisabled() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
         mCountly.setDisableUpdateSessionRequests(true);
@@ -767,7 +747,7 @@ public class CountlyTests {
         when(mockEventQueue.size()).thenReturn(0);
         mCountly.setEventQueue(mockEventQueue);
 
-        mCountly.onStart(null);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         mCountly.onTimer();
 
         verify(mockConnectionQueue, times(0)).updateSession(anyInt());
@@ -776,6 +756,7 @@ public class CountlyTests {
 
     @Test
     public void testOnTimer_activeSession_nonEmptyEventQueue_sessionTimeUpdatesDisabled() {
+        Activity activity = mock(Activity.class);
         final ConnectionQueue mockConnectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(mockConnectionQueue);
         mCountly.setDisableUpdateSessionRequests(true);
@@ -786,7 +767,7 @@ public class CountlyTests {
         when(mockEventQueue.events()).thenReturn(eventData);
         mCountly.setEventQueue(mockEventQueue);
 
-        mCountly.onStart(null);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
         mCountly.onTimer();
 
         verify(mockConnectionQueue, times(0)).updateSession(anyInt());

--- a/sdk/src/androidTest/java/ly/count/android/sdk/CountlyTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/CountlyTests.java
@@ -22,8 +22,6 @@ THE SOFTWARE.
 package ly.count.android.sdk;
 
 import android.app.Activity;
-import android.app.Application;
-import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;

--- a/sdk/src/androidTest/java/ly/count/android/sdk/DeviceInfoTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/DeviceInfoTests.java
@@ -25,6 +25,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.telephony.TelephonyManager;
 import android.util.DisplayMetrics;
@@ -250,35 +251,6 @@ public class DeviceInfoTests {
         json.put("123", "bb");
         json.put("456", "cc");
         json.put("Test", "aa");
-        final String expected = URLEncoder.encode(json.toString(), "UTF-8");
-        assertNotNull(expected);
-        assertEquals(expected, DeviceInfo.getMetrics(getContext(), metricOverride));
-    }
-
-    @Test
-    public void testGetMetricsWithOverride_2() throws UnsupportedEncodingException, JSONException {
-        Map<String, String> metricOverride = new HashMap<>();
-        metricOverride.put("_device", "a1");
-        metricOverride.put("_os", "b2");
-        metricOverride.put("_os_version", "c3");
-        metricOverride.put("_carrier", "d1");
-        metricOverride.put("_resolution", "d2");
-        metricOverride.put("_density", "d3");
-        metricOverride.put("_locale", "d4");
-        metricOverride.put("_app_version", "d5");
-        metricOverride.put("asd", "123");
-
-        final JSONObject json = new JSONObject();
-        json.put("_device", "a1");
-        json.put("_os", "b2");
-        json.put("_os_version", "c3");
-        json.put("_carrier", "d1");
-        json.put("_resolution", "d2");
-        json.put("_density", "d3");
-        json.put("_locale", "d4");
-        json.put("_app_version", "d5");
-        json.put("asd", "123");
-
         final String expected = URLEncoder.encode(json.toString(), "UTF-8");
         assertNotNull(expected);
         assertEquals(expected, DeviceInfo.getMetrics(getContext(), metricOverride));

--- a/sdk/src/androidTest/java/ly/count/android/sdk/DeviceInfoTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/DeviceInfoTests.java
@@ -25,7 +25,6 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.telephony.TelephonyManager;
 import android.util.DisplayMetrics;

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleAPMTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleAPMTests.java
@@ -1,5 +1,6 @@
 package ly.count.android.sdk;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -34,7 +35,7 @@ public class ModuleAPMTests {
         countlyStore.clear();
 
         mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
 
         connectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(connectionQueue);

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleBaseTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleBaseTests.java
@@ -2,6 +2,7 @@ package ly.count.android.sdk;
 
 import android.content.res.Configuration;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -26,7 +27,7 @@ public class ModuleBaseTests {
         countlyStore.clear();
 
         mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
     }
 
     @After

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleConsentTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleConsentTests.java
@@ -1,5 +1,6 @@
 package ly.count.android.sdk;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -59,14 +60,14 @@ public class ModuleConsentTests {
     @Test
     public void enableConsentWithoutConsentGiven(){
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setRequiresConsent(true);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setRequiresConsent(true);
         mCountly.init(config);
     }
 
     @Test
     public void enableConsentGiveAll(){
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setRequiresConsent(true)
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setRequiresConsent(true)
             .setConsentEnabled(usedFeatureNames);
         mCountly.init(config);
     }
@@ -74,7 +75,7 @@ public class ModuleConsentTests {
     @Test
     public void enableConsentRemoveAfter(){
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setRequiresConsent(true)
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setRequiresConsent(true)
             .setConsentEnabled(usedFeatureNames);
         mCountly.init(config);
 

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleCrashTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleCrashTests.java
@@ -1,5 +1,6 @@
 package ly.count.android.sdk;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -35,7 +36,7 @@ public class ModuleCrashTests {
         countlyStore.clear();
 
         mCountly = new Countly();
-        config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
         mCountly.init(config);
 
         connectionQueue = mock(ConnectionQueue.class);
@@ -59,7 +60,7 @@ public class ModuleCrashTests {
         };
 
         Countly countly = new Countly();
-        CountlyConfig cConfig = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        CountlyConfig cConfig = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
         cConfig.setCrashFilterCallback(callback);
 
         countly.init(cConfig);
@@ -70,7 +71,7 @@ public class ModuleCrashTests {
     @Test
     public void crashFilterTest() {
         Countly countly = new Countly();
-        CountlyConfig cConfig = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        CountlyConfig cConfig = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
         cConfig.setCrashFilterCallback(new CrashFilterCallback() {
             @Override
             public boolean filterCrash(String crash) {
@@ -111,7 +112,7 @@ public class ModuleCrashTests {
     public void setCustomCrashSegment() {
         CrashDetails.customSegments = null;
         Countly countly = new Countly();
-        CountlyConfig cConfig = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        CountlyConfig cConfig = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
 
         Map<String, Object> segmIn = CrashDetails.customSegments;
         Assert.assertTrue(segmIn == null || segmIn.size() == 0);

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleEventsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleEventsTests.java
@@ -1,5 +1,6 @@
 package ly.count.android.sdk;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -35,7 +36,7 @@ public class ModuleEventsTests {
         countlyStore.clear();
 
         mCountly = new Countly();
-        config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
         mCountly.init(config);
 
         eventQueue = mock(EventQueue.class);

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleRatingsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleRatingsTests.java
@@ -1,5 +1,6 @@
 package ly.count.android.sdk;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
@@ -28,7 +29,7 @@ public class ModuleRatingsTests {
         countlyStore.clear();
 
         mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
         mCountly.init(config);
     }
 
@@ -95,7 +96,7 @@ public class ModuleRatingsTests {
     @Test
     public void getAutomaticSessionLimit() {
         Countly countly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setStarRatingSessionLimit(44);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setStarRatingSessionLimit(44);
         countly.init(config);
         Assert.assertEquals(44, countly.ratings().getAutomaticStarRatingSessionLimit());
     }
@@ -121,7 +122,7 @@ public class ModuleRatingsTests {
         Assert.assertFalse(mCountly.moduleRatings.getIfStarRatingShouldBeShownAutomatically());
 
         Countly countly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setIfStarRatingShownAutomatically(true);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setIfStarRatingShownAutomatically(true);
         countly.init(config);
 
         Assert.assertTrue(countly.moduleRatings.getIfStarRatingShouldBeShownAutomatically());
@@ -149,7 +150,7 @@ public class ModuleRatingsTests {
 
     @Test
     public void setAllFieldsDuringInit() {
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setStarRatingSessionLimit(44);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setStarRatingSessionLimit(44);
         config.setStarRatingDisableAskingForEachAppVersion(true);
         config.setStarRatingSessionLimit(445);
         config.setIfStarRatingShownAutomatically(true);

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleSessionsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleSessionsTests.java
@@ -1,19 +1,16 @@
 package ly.count.android.sdk;
 
+import android.app.Activity;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static androidx.test.InstrumentationRegistry.getContext;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,7 +26,7 @@ public class ModuleSessionsTests {
         countlyStore.clear();
 
         mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
     }
 
     @After
@@ -39,7 +36,7 @@ public class ModuleSessionsTests {
     @Test
     public void manualSessionBegin(){
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().enableManualSessionControl();
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().enableManualSessionControl();
 
         mCountly.init(config);
         ConnectionQueue connectionQueue = mock(ConnectionQueue.class);
@@ -53,7 +50,7 @@ public class ModuleSessionsTests {
     @Test
     public void manualSessionBeginUpdateEnd() throws InterruptedException {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().enableManualSessionControl();
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().enableManualSessionControl();
 
         mCountly.init(config);
         ConnectionQueue connectionQueue = mock(ConnectionQueue.class);
@@ -75,7 +72,7 @@ public class ModuleSessionsTests {
     @Test
     public void manualSessionBeginUpdateEndManualDisabled() throws InterruptedException {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
 
         mCountly.init(config);
         ConnectionQueue connectionQueue = mock(ConnectionQueue.class);
@@ -96,7 +93,7 @@ public class ModuleSessionsTests {
     @Test
     public void automaticSessionBeginEndWithManualEnabled() throws InterruptedException {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().enableManualSessionControl();
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().enableManualSessionControl();
 
         mCountly.init(config);
         ConnectionQueue connectionQueue = mock(ConnectionQueue.class);
@@ -115,18 +112,23 @@ public class ModuleSessionsTests {
     @Test
     public void automaticSessionBeginEndWithManualDisabled() throws InterruptedException {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        Activity activity = mock(Activity.class);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
 
         mCountly.init(config);
         ConnectionQueue connectionQueue = mock(ConnectionQueue.class);
         mCountly.setConnectionQueue(connectionQueue);
 
-        mCountly.onStart(null);
+        mCountly.activityLifecycleCallbacks_.onActivityStarted(activity);
 
         verify(connectionQueue, times(1)).beginSession();
-        Thread.sleep(1000);
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ex) {
+            fail("sleep failed");
+        }
 
-        mCountly.onStop();
+        mCountly.activityLifecycleCallbacks_.onActivityStopped(activity);
 
         verify(connectionQueue, times(1)).endSession(1, null);
     }

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleViewsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleViewsTests.java
@@ -3,8 +3,6 @@ package ly.count.android.sdk;
 import android.app.Activity;
 import android.content.res.Configuration;
 
-import androidx.lifecycle.Lifecycle;
-import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleViewsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleViewsTests.java
@@ -2,12 +2,11 @@ package ly.count.android.sdk;
 
 import android.app.Activity;
 import android.content.res.Configuration;
-import android.view.KeyEvent;
-import android.view.View;
 
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import net.bytebuddy.asm.Advice;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -16,9 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.mockito.ArgumentMatchers;
 
@@ -28,18 +25,15 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(AndroidJUnit4.class)
 public class ModuleViewsTests {
@@ -51,7 +45,7 @@ public class ModuleViewsTests {
         countlyStore.clear();
 
         //mCountly = new Countly();
-        //mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
+        //mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting());
     }
 
     @After
@@ -70,7 +64,7 @@ public class ModuleViewsTests {
 
     void activityStartedViewTracking(boolean shortNames){
         Countly mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(shortNames));
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(shortNames));
         EventQueue evQ = mock(EventQueue.class);
         mCountly.setEventQueue(evQ);
 
@@ -112,7 +106,7 @@ public class ModuleViewsTests {
         Activity act2 = mock(Activity2.class);
 
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(shortNames).setAutoTrackingExceptions(new Class[]{act1.getClass()});
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(shortNames).setAutoTrackingExceptions(new Class[]{act1.getClass()});
         mCountly.init(config);
         EventQueue evQ = mock(EventQueue.class);
         mCountly.setEventQueue(evQ);
@@ -144,7 +138,7 @@ public class ModuleViewsTests {
     @Test
     public void onActivityStartedDisabledOrientationView(){
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
         mCountly.init(config);
 
         EventQueue evQ = mock(EventQueue.class);
@@ -159,7 +153,7 @@ public class ModuleViewsTests {
     @Test
     public void onActivityStartedOrientation(){
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setTrackOrientationChanges(true);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setTrackOrientationChanges(true);
         mCountly.init(config);
 
         EventQueue evQ = mock(EventQueue.class);
@@ -190,7 +184,7 @@ public class ModuleViewsTests {
     @Test
     public void onConfigurationChangedOrientationDisabled() {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting();
         mCountly.init(config);
 
         EventQueue evQ = mock(EventQueue.class);
@@ -213,7 +207,7 @@ public class ModuleViewsTests {
     @Test
     public void onConfigurationChangedOrientation() {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setTrackOrientationChanges(true);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setTrackOrientationChanges(true);
         mCountly.init(config);
 
         EventQueue evQ = mock(EventQueue.class);
@@ -243,12 +237,12 @@ public class ModuleViewsTests {
     @Test
     public void onActivityStopped(){
         Countly mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true));
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true));
         EventQueue evQ = mock(EventQueue.class);
 
         mCountly.setEventQueue(evQ);
 
-        mCountly.moduleViews.onActivityStopped();
+        mCountly.moduleViews.onActivityStopped(mock(Activity.class));
 
         verify(evQ, never()).recordEvent(anyString(), any(Map.class), any(Map.class), any(Map.class), any(Map.class), anyInt(), anyDouble(), anyDouble(), any(UtilsTime.Instant.class));
     }
@@ -256,7 +250,7 @@ public class ModuleViewsTests {
     @Test
     public void onActivityStartedStopped() throws InterruptedException {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true);
 
         Map<String, Object> segms = new HashMap<>();
         segms.put("aa", "11");
@@ -279,7 +273,7 @@ public class ModuleViewsTests {
 
         Thread.sleep(100);
 
-        mCountly.moduleViews.onActivityStopped();
+        mCountly.moduleViews.onActivityStopped(act);
         String dur = String.valueOf(UtilsTime.currentTimestampSeconds() - start);
 
         final Map<String, String> segmS = new HashMap<>(4);
@@ -316,7 +310,7 @@ public class ModuleViewsTests {
     @Test
     public void recordViewNoSegm() throws InterruptedException {
         Countly mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true));
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true));
         EventQueue evQ = mock(EventQueue.class);
         mCountly.setEventQueue(evQ);
 
@@ -337,6 +331,7 @@ public class ModuleViewsTests {
         verify(evQ, times(1)).recordEvent(ModuleViews.VIEW_EVENT_KEY, segmS, segmI, segmD, segmB, 1, 0, 0, null);
         Thread.sleep(1000);
 
+        mCountly.views().endViewRecording(viewNames[0]);
         mCountly.views().recordView(viewNames[1]);
         segmS.clear();
         segmS.put("dur", "1");
@@ -351,6 +346,7 @@ public class ModuleViewsTests {
         verify(evQ, times(1)).recordEvent(ModuleViews.VIEW_EVENT_KEY, segmS, segmI, segmD, segmB, 1, 0, 0, null);
 
         Thread.sleep(1000);
+        mCountly.views().endViewRecording(viewNames[1]);
         mCountly.views().recordView(viewNames[2]);
         segmS.clear();
         segmS.put("dur", "1");
@@ -368,7 +364,7 @@ public class ModuleViewsTests {
     @Test
     public void recordViewWithSegm() throws InterruptedException {
         Countly mCountly = new Countly();
-        CountlyConfig config = (new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true);
+        CountlyConfig config = (new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true);
 
         Map<String, Object> segms = new HashMap<>();
         segms.put("aa", "11");
@@ -421,6 +417,7 @@ public class ModuleViewsTests {
         verify(evQ, times(1)).recordEvent(ModuleViews.VIEW_EVENT_KEY, segmS, segmI, segmD, segmB, 1, 0, 0, null);
         Thread.sleep(1000);
 
+        mCountly.views().endViewRecording(viewNames[0]);
         mCountly.views().recordView(viewNames[1], cSegm2);
         segmS.clear();
         segmI.clear();
@@ -446,6 +443,7 @@ public class ModuleViewsTests {
         verify(evQ, times(1)).recordEvent(ModuleViews.VIEW_EVENT_KEY, segmS, segmI, segmD, segmB, 1, 0, 0, null);
 
         Thread.sleep(1000);
+        mCountly.views().endViewRecording(viewNames[1]);
         mCountly.views().recordView(viewNames[2], cSegm3);
         segmS.clear();
         segmI.clear();
@@ -477,7 +475,7 @@ public class ModuleViewsTests {
     @Test
     public void recordViewNullViewName()  {
         Countly mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true));
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true));
         EventQueue evQ = mock(EventQueue.class);
         mCountly.setEventQueue(evQ);
 
@@ -505,7 +503,7 @@ public class ModuleViewsTests {
     @Test
     public void recordViewEmptyViewName()  {
         Countly mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true));
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting().setViewTracking(true).setAutoTrackingUseShortName(true));
         EventQueue evQ = mock(EventQueue.class);
         mCountly.setEventQueue(evQ);
 
@@ -533,7 +531,7 @@ public class ModuleViewsTests {
     @Test
     public void recordViewWithoutConsent()  {
         Countly mCountly = new Countly();
-        mCountly.init((new CountlyConfig(getContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting()
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(), "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting()
             .setViewTracking(true).setAutoTrackingUseShortName(true).setRequiresConsent(true));
 
         EventQueue evQ = mock(EventQueue.class);
@@ -558,5 +556,71 @@ public class ModuleViewsTests {
         System.out.println(mockingDetails(mEvents).getInvocations());
 
         verify(mEvents, times(0)).recordEventInternal(argS.capture(), argM.capture(), argI.capture(), argD1.capture(), argD2.capture(), argInst.capture(), argB.capture());
+    }
+
+    @Test
+    public void recordActivityByIdentity() {
+        Countly mCountly = new Countly();
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(),
+            "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting()
+            .setViewTracking(true).setAutoTrackingUseShortName(true).setRequiresConsent(false));
+        EventQueue evQ = mock(EventQueue.class);
+        mCountly.setEventQueue(evQ);
+        ModuleEvents mEvents = mock(ModuleEvents.class);
+        mCountly.moduleEvents = mEvents;
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        mCountly.views().recordView(obj1);
+        Assert.assertEquals(1, mCountly.moduleViews.identityStartTimes.size());
+        mCountly.views().recordView(obj2);
+        Assert.assertEquals(2, mCountly.moduleViews.identityStartTimes.size());
+        mCountly.views().endViewRecording(obj2);
+        Assert.assertEquals(1, mCountly.moduleViews.identityStartTimes.size());
+        mCountly.views().endViewRecording(obj1);
+        Assert.assertEquals(0, mCountly.moduleViews.identityStartTimes.size());
+        verify(mEvents, times(4)).recordEventInternal(anyString(), any(Map.class), anyInt(), anyDouble(), anyDouble(), ArgumentMatchers.<UtilsTime.Instant>isNull(), anyBoolean());
+    }
+
+
+    @PersistentName("Foo")
+    private static class PersistentNameObject { }
+
+    @Test
+    public void usePersistentName() {
+        Countly mCountly = new Countly();
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(),
+            "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting()
+            .setViewTracking(true).setAutoTrackingUseShortName(true).setRequiresConsent(false));
+        EventQueue evQ = mock(EventQueue.class);
+        mCountly.setEventQueue(evQ);
+        ModuleEvents mEvents = mock(ModuleEvents.class);
+        mCountly.moduleEvents = mEvents;
+        PersistentNameObject obj = new PersistentNameObject();
+        mCountly.views().recordView(obj);
+        ArgumentCaptor<Map<String, Object>> argMap = ArgumentCaptor.forClass(Map.class);
+        verify(mEvents, times(1)).recordEventInternal(anyString(), argMap.capture(), anyInt(), anyDouble(), anyDouble(), ArgumentMatchers.<UtilsTime.Instant>isNull(), anyBoolean());
+        Map<String, Object> map = argMap.getValue();
+        String name = (String) map.get("name");
+        Assert.assertNotNull(name);
+        //noinspection ConstantConditions
+        Assert.assertEquals(PersistentNameObject.class.getAnnotation(PersistentName.class).value(), name);
+    }
+
+    @DoNotTrack
+    private static class DoNotTrackObject { }
+
+    @Test
+    public void ignoreDoNotTrackObject() {
+        Countly mCountly = new Countly();
+        mCountly.init((new CountlyConfig((TestApplication) ApplicationProvider.getApplicationContext(),
+            "appkey", "http://test.count.ly")).setDeviceId("1234").setLoggingEnabled(true).enableCrashReporting()
+            .setViewTracking(true).setAutoTrackingUseShortName(true).setRequiresConsent(false));
+        EventQueue evQ = mock(EventQueue.class);
+        mCountly.setEventQueue(evQ);
+        ModuleEvents mEvents = mock(ModuleEvents.class);
+        mCountly.moduleEvents = mEvents;
+        DoNotTrackObject obj = new DoNotTrackObject();
+        mCountly.views().recordView(obj);
+        verifyZeroInteractions(mEvents);
     }
 }

--- a/sdk/src/androidTest/java/ly/count/android/sdk/TestApplication.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/TestApplication.java
@@ -1,0 +1,6 @@
+package ly.count.android.sdk;
+
+import android.app.Application;
+
+public class TestApplication extends Application {
+}

--- a/sdk/src/androidTest/java/ly/count/android/sdk/UtilsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/UtilsTests.java
@@ -55,15 +55,6 @@ public class UtilsTests {
     }
 
     @Test
-    public void testAPI() {
-        Assert.assertTrue(Utils.API(28));
-        Assert.assertTrue(Utils.API(27));
-        Assert.assertTrue(Utils.API(15));
-
-        Assert.assertFalse(Utils.API(32));
-    }
-
-    @Test
     public void removeKeysFromMapNullBoth(){
         Map<String, Object> res = Utils.removeKeysFromMap(null, null);
         Assert.assertNull(res);

--- a/sdk/src/androidTest/res/values/colors.xml
+++ b/sdk/src/androidTest/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorPrimary">#008577</color>
+    <color name="colorPrimaryDark">#00574B</color>
+    <color name="colorAccent">#D81B60</color>
+</resources>

--- a/sdk/src/androidTest/res/values/strings.xml
+++ b/sdk/src/androidTest/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Test</string>
+</resources>

--- a/sdk/src/androidTest/res/values/styles.xml
+++ b/sdk/src/androidTest/res/values/styles.xml
@@ -1,0 +1,9 @@
+<resources>
+
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+</resources>

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
@@ -45,6 +45,7 @@ import javax.net.ssl.TrustManager;
  * of this bug in dexmaker: https://code.google.com/p/dexmaker/issues/detail?id=34
  */
 public class ConnectionQueue {
+    private Countly cly_;
     private CountlyStore store_;
     private ExecutorService executor_;
     private String appKey_;
@@ -56,6 +57,10 @@ public class ConnectionQueue {
 
     private Map<String, String> requestHeaderCustomValues;
     Map<String, String> metricOverride = null;
+
+    public ConnectionQueue(Countly countly) {
+        this.cly_ = countly;
+    }
 
     // Getters are for unit testing
     String getAppKey() {
@@ -148,14 +153,14 @@ public class ConnectionQueue {
      */
     void beginSession() {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] beginSession");
         }
 
         boolean dataAvailable = false;//will only send data if there is something valuable to send
         String data = prepareCommonRequestData();
 
-        if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
+        if (cly_.consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
             //add session data if consent given
             data += "&begin_session=1"
                 + "&metrics=" + DeviceInfo.getMetrics(context_, metricOverride);//can be only sent with begin session
@@ -170,9 +175,9 @@ public class ConnectionQueue {
             dataAvailable = true;
         }
 
-        if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.attribution)) {
+        if (cly_.consent().getConsent(Countly.CountlyFeatureNames.attribution)) {
             //add attribution data if consent given
-            if (Countly.sharedInstance().isAttributionEnabled) {
+            if (cly_.isAttributionEnabled) {
                 String cachedAdId = store_.getCachedAdvertisingId();
 
                 if (!cachedAdId.isEmpty()) {
@@ -183,7 +188,7 @@ public class ConnectionQueue {
             }
         }
 
-        Countly.sharedInstance().isBeginSessionSent = true;
+        cly_.isBeginSessionSent = true;
 
         if (dataAvailable) {
             store_.addConnection(data);
@@ -200,7 +205,7 @@ public class ConnectionQueue {
      */
     void updateSession(final int duration) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] updateSession");
         }
 
@@ -208,13 +213,13 @@ public class ConnectionQueue {
             boolean dataAvailable = false;//will only send data if there is something valuable to send
             String data = prepareCommonRequestData();
 
-            if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
+            if (cly_.consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
                 data += "&session_duration=" + duration;
                 dataAvailable = true;
             }
 
-            if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.attribution)) {
-                if (Countly.sharedInstance().isAttributionEnabled) {
+            if (cly_.consent().getConsent(Countly.CountlyFeatureNames.attribution)) {
+                if (cly_.isAttributionEnabled) {
                     String cachedAdId = store_.getCachedAdvertisingId();
 
                     if (!cachedAdId.isEmpty()) {
@@ -233,12 +238,12 @@ public class ConnectionQueue {
 
     public void changeDeviceId(String deviceId, final int duration) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] changeDeviceId");
         }
 
-        if (!Countly.sharedInstance().anyConsentGiven()) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.anyConsentGiven()) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             //no consent set, aborting
@@ -247,7 +252,7 @@ public class ConnectionQueue {
 
         String data = prepareCommonRequestData();
 
-        if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
+        if (cly_.consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
             data += "&session_duration=" + duration;
         }
 
@@ -260,12 +265,12 @@ public class ConnectionQueue {
 
     public void tokenSession(String token, Countly.CountlyMessagingMode mode, Countly.CountlyMessagingProvider provider) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] tokenSession");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.push)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.push)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -278,7 +283,7 @@ public class ConnectionQueue {
             + "&test_mode=" + (mode == Countly.CountlyMessagingMode.TEST ? 2 : 0)
             + "&locale=" + DeviceInfo.getLocale();
 
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] Waiting for 10 seconds before adding token request to queue");
         }
 
@@ -287,7 +292,7 @@ public class ConnectionQueue {
         worker.schedule(new Runnable() {
             @Override
             public void run() {
-                if (Countly.sharedInstance().isLoggingEnabled()) {
+                if (cly_.isLoggingEnabled()) {
                     Log.d(Countly.TAG, "[Connection Queue] Finished waiting 10 seconds adding token request");
                 }
                 store_.addConnection(data);
@@ -309,14 +314,14 @@ public class ConnectionQueue {
 
     void endSession(final int duration, String deviceIdOverride) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] endSession");
         }
 
         boolean dataAvailable = false;//will only send data if there is something valuable to send
         String data = prepareCommonRequestData();
 
-        if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
+        if (cly_.consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
             data += "&end_session=1";
             if (duration > 0) {
                 data += "&session_duration=" + duration;
@@ -324,7 +329,7 @@ public class ConnectionQueue {
             dataAvailable = true;
         }
 
-        if (deviceIdOverride != null && Countly.sharedInstance().anyConsentGiven()) {
+        if (deviceIdOverride != null && cly_.anyConsentGiven()) {
             //if no consent is given, device ID override is not sent
             data += "&override_id=" + UtilsNetworking.urlEncodeString(deviceIdOverride);
             dataAvailable = true;
@@ -341,7 +346,7 @@ public class ConnectionQueue {
      */
     void sendLocation() {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendLocation");
         }
 
@@ -362,12 +367,12 @@ public class ConnectionQueue {
      */
     void sendUserData() {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendUserData");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.users)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.users)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -392,12 +397,12 @@ public class ConnectionQueue {
      */
     void sendReferrerData(String referrer) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] checkInternalState");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.attribution)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.attribution)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -419,12 +424,12 @@ public class ConnectionQueue {
      */
     void sendCrashReport(String error, boolean nonfatal, boolean isNativeCrash, final Map<String, Object> customSegmentation) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendCrashReport");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.crashes)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.crashes)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -451,7 +456,7 @@ public class ConnectionQueue {
      */
     void recordEvents(final String events) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendConsentChanges");
         }
 
@@ -468,7 +473,7 @@ public class ConnectionQueue {
 
     void sendConsentChanges(String formattedConsentChanges) {
         checkInternalState();
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendConsentChanges");
         }
 
@@ -483,12 +488,12 @@ public class ConnectionQueue {
     void sendAPMCustomTrace(String key, Long durationMs, Long startMs, Long endMs, String customMetrics) {
         checkInternalState();
 
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendAPMCustomTrace");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.apm)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.apm)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -512,12 +517,12 @@ public class ConnectionQueue {
     void sendAPMNetworkTrace(String networkTraceKey, Long responseTimeMs, int responseCode, int requestPayloadSize, int responsePayloadSize, Long startMs, Long endMs) {
         checkInternalState();
 
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendAPMNetworkTrace");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.apm)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.apm)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -542,12 +547,12 @@ public class ConnectionQueue {
     void sendAPMAppStart(long durationMs, Long startMs, Long endMs) {
         checkInternalState();
 
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendAPMAppStart");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.apm)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.apm)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -569,12 +574,12 @@ public class ConnectionQueue {
     void sendAPMScreenTime(boolean recordForegroundTime, long durationMs, Long startMs, Long endMs) {
         checkInternalState();
 
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Connection Queue] sendAPMScreenTime, recording foreground time: [" + recordForegroundTime + "]");
         }
 
-        if (!Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.apm)) {
-            if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (!cly_.consent().getConsent(Countly.CountlyFeatureNames.apm)) {
+            if (cly_.isLoggingEnabled()) {
                 Log.d(Countly.TAG, "[Connection Queue] request ignored, consent not given");
             }
             return;
@@ -601,20 +606,20 @@ public class ConnectionQueue {
             + "&hour=" + instant.hour
             + "&dow=" + instant.dow
             + "&tz=" + DeviceInfo.getTimezoneOffset()
-            + "&sdk_version=" + Countly.sharedInstance().COUNTLY_SDK_VERSION_STRING
-            + "&sdk_name=" + Countly.sharedInstance().COUNTLY_SDK_NAME;
+            + "&sdk_version=" + cly_.COUNTLY_SDK_VERSION_STRING
+            + "&sdk_name=" + cly_.COUNTLY_SDK_NAME;
     }
 
     private String prepareLocationData(CountlyStore cs, boolean canSendEmptyWithNoConsent) {
         String data = "";
 
-        if (canSendEmptyWithNoConsent && (cs.getLocationDisabled() || !Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.location))) {
+        if (canSendEmptyWithNoConsent && (cs.getLocationDisabled() || !cly_.consent().getConsent(Countly.CountlyFeatureNames.location))) {
             //if location is disabled or consent not given, send empty location info
             //this way it is cleared server side and geoip is not used
             //do this only if allowed
             data += "&location=";
         } else {
-            if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.location)) {
+            if (cly_.consent().getConsent(Countly.CountlyFeatureNames.location)) {
                 //location should be send, add all the fields we have
                 String location = cs.getLocation();
                 String city = cs.getLocationCity();
@@ -646,7 +651,7 @@ public class ConnectionQueue {
             + "&method=fetch_remote_config"
             + "&device_id=" + UtilsNetworking.urlEncodeString(deviceId_.getId());
 
-        if (Countly.sharedInstance().consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
+        if (cly_.consent().getConsent(Countly.CountlyFeatureNames.sessions)) {
             //add session data if consent given
             data += "&metrics=" + DeviceInfo.getMetrics(context_, metricOverride);
         }
@@ -688,7 +693,7 @@ public class ConnectionQueue {
      * is already running.
      */
     void tick() {
-        if (Countly.sharedInstance().isLoggingEnabled()) {
+        if (cly_.isLoggingEnabled()) {
             Log.v(Countly.TAG, "[Connection Queue] tick, Not empty:[" + !store_.isEmptyConnections() + "], Has processor:[" + (connectionProcessorFuture_ == null) + "], Done or null:[" + (connectionProcessorFuture_ == null
                 || connectionProcessorFuture_.isDone()) + "]");
         }

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
@@ -175,16 +175,14 @@ public class ConnectionQueue {
             dataAvailable = true;
         }
 
-        if (cly_.consent().getConsent(Countly.CountlyFeatureNames.attribution)) {
+        if (cly_.consent().getConsent(Countly.CountlyFeatureNames.attribution) && cly_.isAttributionEnabled) {
             //add attribution data if consent given
-            if (cly_.isAttributionEnabled) {
-                String cachedAdId = store_.getCachedAdvertisingId();
+            String cachedAdId = store_.getCachedAdvertisingId();
 
-                if (!cachedAdId.isEmpty()) {
-                    data += "&aid=" + UtilsNetworking.urlEncodeString("{\"adid\":\"" + cachedAdId + "\"}");
+            if (!cachedAdId.isEmpty()) {
+                data += "&aid=" + UtilsNetworking.urlEncodeString("{\"adid\":\"" + cachedAdId + "\"}");
 
-                    dataAvailable = true;
-                }
+                dataAvailable = true;
             }
         }
 

--- a/sdk/src/main/java/ly/count/android/sdk/Countly.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Countly.java
@@ -22,15 +22,18 @@ THE SOFTWARE.
 package ly.count.android.sdk;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.app.Application;
+import android.content.ComponentCallbacks;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -94,6 +97,8 @@ public class Countly {
     protected static List<String> publicKeyPinCertificates;
     protected static List<String> certificatePinCertificates;
 
+    boolean autoViewTracker = false;
+
     /**
      * Enum used in Countly.initMessaging() method which controls what kind of
      * app installation it is. Later (in Countly Dashboard or when calling Countly API method),
@@ -152,7 +157,6 @@ public class Countly {
     public static UserData userData;
 
     //view related things
-    boolean autoViewTracker = false;//todo, move to module after "setViewTracking" is removed
     boolean automaticTrackingShouldUseShortName = false;//flag for using short names | todo, move to module after setter is removed
 
     //if set to true, it will automatically download remote configs on module startup
@@ -194,9 +198,172 @@ public class Countly {
     Boolean delayedPushConsent = null;//if this is set, consent for push has to be set before finishing init and sending push changes
     boolean delayedLocationErasure = false;//if location needs to be cleared at the end of init
 
-    private boolean appLaunchDeepLink = true;
+    boolean appLaunchDeepLink = true;
 
     CountlyConfig config_ = null;
+
+    private final ComponentCallbacks componentCallbacks_ = new ComponentCallbacks() {
+        @Override
+        public void onConfigurationChanged(@NonNull Configuration configuration) {
+            if (isLoggingEnabled()) {
+                Log.d(Countly.TAG, "Calling [onConfigurationChanged]");
+            }
+            if (!isInitialized()) {
+                throw new IllegalStateException("init must be called before onConfigurationChanged");
+            }
+
+            for (ModuleBase module : modules) {
+                module.onConfigurationChanged(configuration);
+            }
+        }
+
+        @Override
+        public void onLowMemory() { }
+    };
+
+    private final androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks supportFragmentLifecycleCallbacks_ = new androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks() {
+
+        @Override
+        public void onFragmentStarted(@NonNull androidx.fragment.app.FragmentManager fm, @NonNull androidx.fragment.app.Fragment f) {
+            if (!fragmentVerify(f, "Started")) {
+                return;
+            }
+            for (ModuleBase module : modules) {
+                module.onFragmentStarted(f);
+            }
+        }
+
+        @Override
+        public void onFragmentStopped(@NonNull androidx.fragment.app.FragmentManager fm, @NonNull androidx.fragment.app.Fragment f) {
+            if (!fragmentVerify(f, "Stopped")) {
+                return;
+            }
+            for (ModuleBase module : modules) {
+                module.onFragmentStopped(f);
+            }
+        }
+    };
+
+    private <F> boolean fragmentVerify(@NonNull F fragment, @NonNull String eventVerb) {
+        if (!isInitialized()) {
+            // do NOT throw, just return false. we cannot reacquire references to all fragment managers to
+            // unregister all callbacks recursively.
+            return false;
+        }
+        if (isLoggingEnabled()) {
+            Log.d(Countly.TAG, "[Countly] onFragment" + eventVerb + ", " + getViewName(fragment));
+        }
+        return true;
+    }
+
+    private android.app.FragmentManager.FragmentLifecycleCallbacks legacyFragmentLifecycleCallbacks = null;
+
+    private void activityVerify(@NonNull android.app.Activity activity, @NonNull String eventVerb) {
+        if (!isInitialized()) {
+            throw new IllegalStateException("Countly not initialized");
+        }
+        if (isLoggingEnabled()) {
+            Log.d(Countly.TAG, "[Countly] onActivity" + eventVerb + ", " + getViewName(activity));
+        }
+    }
+
+    @VisibleForTesting final Application.ActivityLifecycleCallbacks activityLifecycleCallbacks_ = new Application.ActivityLifecycleCallbacks() {
+
+        @Override
+        public void onActivityCreated(@NonNull android.app.Activity activity, Bundle bundle) {
+            activityVerify(activity, "Created");
+            if (activity instanceof androidx.fragment.app.FragmentActivity) {
+                // This is a support lib Activity. Use supportFragmentManager
+                androidx.fragment.app.FragmentActivity fragmentActivity = (androidx.fragment.app.FragmentActivity) activity;
+                fragmentActivity.getSupportFragmentManager().registerFragmentLifecycleCallbacks(supportFragmentLifecycleCallbacks_, true);
+            } else {
+                // This is not a support lib Activity. Use legacy fragmentManager if we're on a sufficiently new device
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    activity.getFragmentManager().registerFragmentLifecycleCallbacks(legacyFragmentLifecycleCallbacks, true);
+                }
+            }
+            onCreateInternal(activity);
+            for (ModuleBase module : modules) {
+                module.onActivityCreated(activity);
+            }
+        }
+
+        @Override
+        public void onActivityStarted(@NonNull android.app.Activity activity) {
+            activityVerify(activity, "Started");
+            appLaunchDeepLink = false;
+            ++activityCount_;
+            //check if there is an install referrer data
+            String referrer = ReferrerReceiver.getReferrer(context_);
+            if (isLoggingEnabled()) {
+                Log.d(Countly.TAG, "Checking referrer: " + referrer);
+            }
+            if (referrer != null) {
+                connectionQueue_.sendReferrerData(referrer);
+                ReferrerReceiver.deleteReferrer(context_);
+            }
+            if (activityCount_ == 1 && !moduleSessions.manualSessionControlEnabled) {
+                //if we open the first activity
+                //and we are not using manual session control,
+                //begin a session
+                moduleSessions.beginSessionInternal();
+                CrashDetails.inForeground();
+            }
+            calledAtLeastOnceOnStart = true;
+            for (ModuleBase module : modules) {
+                module.onActivityStarted(activity);
+            }
+        }
+
+        @Override
+        public void onActivityResumed(android.app.Activity activity) {
+            activityVerify(activity, "Resumed");
+            for (ModuleBase module : modules) {
+                module.onActivityResumed(activity);
+            }
+        }
+
+        @Override
+        public void onActivityPaused(@NonNull android.app.Activity activity) {
+            activityVerify(activity, "Paused");
+            for (ModuleBase module : modules) {
+                module.onActivityPaused(activity);
+            }
+        }
+
+        @Override
+        public void onActivityStopped(@NonNull android.app.Activity activity) {
+            activityVerify(activity, "Stopped");
+            if (activityCount_ == 0) {
+                throw new IllegalStateException("must call onStart before onStop");
+            }
+
+            --activityCount_;
+            if (activityCount_ == 0) {
+                // if we don't use manual session control
+                // Called when final Activity is stopped.
+                // Sends an end session event to the server, also sends any unsent custom events.
+                if (!moduleSessions.manualSessionControlEnabled) {
+                    moduleSessions.endSessionInternal(null);
+                }
+                CrashDetails.inBackground();
+            }
+            for (ModuleBase module : modules) {
+                module.onActivityStopped(activity);
+            }
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(@NonNull android.app.Activity activity, @NonNull Bundle bundle) { }
+
+        @Override
+        public void onActivityDestroyed(@NonNull android.app.Activity activity) {
+            activityVerify(activity, "Destroyed");
+            for (ModuleBase module : modules) {
+                module.onActivityDestroyed(activity);
+            }
+        }
+    };
 
     public static class CountlyFeatureNames {
         public static final String sessions = "sessions";
@@ -248,7 +415,7 @@ public class Countly {
     }
 
     private void staticInit(){
-        connectionQueue_ = new ConnectionQueue();
+        connectionQueue_ = new ConnectionQueue(this);
         Countly.userData = new UserData(connectionQueue_);
         startTimerService(timerService_, timerFuture, TIMER_DELAY_IN_SECONDS);
     }
@@ -389,6 +556,10 @@ public class Countly {
 
         if (config.context == null) {
             throw new IllegalArgumentException("valid context is required in Countly init, but was provided 'null'");
+        }
+
+        if (config.application == null) {
+            throw new IllegalArgumentException("Application reference is required");
         }
 
         if (!UtilsNetworking.isValidURL(config.serverURL)) {
@@ -669,97 +840,30 @@ public class Countly {
 
             //set global application listeners
             if (config.application != null) {
-                config.application.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
-                    @Override
-                    public void onActivityCreated(Activity activity, Bundle bundle) {
-                        if (isLoggingEnabled()) {
-                            String actName = activity.getClass().getSimpleName();
-                            Log.d(Countly.TAG, "[Countly] onActivityCreated, " + actName);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    legacyFragmentLifecycleCallbacks = new android.app.FragmentManager.FragmentLifecycleCallbacks() {
+                        @Override
+                        public void onFragmentStarted(android.app.FragmentManager fm, android.app.Fragment f) {
+                            if (!fragmentVerify(f, "Started")) {
+                                return;
+                            }
+                            for (ModuleBase module : modules) {
+                                module.onFragmentStarted(f);
+                            }
                         }
-                        for (ModuleBase module : modules) {
-                            module.callbackOnActivityCreated(activity);
+                        @Override
+                        public void onFragmentStopped(android.app.FragmentManager fm, android.app.Fragment f) {
+                            if (!fragmentVerify(f, "Stopped")) {
+                                return;
+                            }
+                            for (ModuleBase module : modules) {
+                                module.onFragmentStopped(f);
+                            }
                         }
-                    }
-
-                    @Override
-                    public void onActivityStarted(Activity activity) {
-                        if (isLoggingEnabled()) {
-                            String actName = activity.getClass().getSimpleName();
-                            Log.d(Countly.TAG, "[Countly] onActivityStarted, " + actName);
-                        }
-                        for (ModuleBase module : modules) {
-                            module.callbackOnActivityStarted(activity);
-                        }
-                    }
-
-                    @Override
-                    public void onActivityResumed(Activity activity) {
-                        if (isLoggingEnabled()) {
-                            String actName = activity.getClass().getSimpleName();
-                            Log.d(Countly.TAG, "[Countly] onActivityResumed, " + actName);
-                        }
-                        for (ModuleBase module : modules) {
-                            module.callbackOnActivityResumed(activity);
-                        }
-                    }
-
-                    @Override
-                    public void onActivityPaused(Activity activity) {
-                        if (isLoggingEnabled()) {
-                            String actName = activity.getClass().getSimpleName();
-                            Log.d(Countly.TAG, "[Countly] onActivityPaused, " + actName);
-                        }
-                        for (ModuleBase module : modules) {
-                            module.callbackOnActivityPaused(activity);
-                        }
-                    }
-
-                    @Override
-                    public void onActivityStopped(Activity activity) {
-                        if (isLoggingEnabled()) {
-                            String actName = activity.getClass().getSimpleName();
-                            Log.d(Countly.TAG, "[Countly] onActivityStopped, " + actName);
-                        }
-                        for (ModuleBase module : modules) {
-                            module.callbackOnActivityStopped(activity);
-                        }
-                    }
-
-                    @Override
-                    public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
-                        if (isLoggingEnabled()) {
-                            String actName = activity.getClass().getSimpleName();
-                            Log.d(Countly.TAG, "[Countly] onActivitySaveInstanceState, " + actName);
-                        }
-                        for (ModuleBase module : modules) {
-                            module.callbackOnActivitySaveInstanceState(activity);
-                        }
-                    }
-
-                    @Override
-                    public void onActivityDestroyed(Activity activity) {
-                        if (isLoggingEnabled()) {
-                            String actName = activity.getClass().getSimpleName();
-                            Log.d(Countly.TAG, "[Countly] onActivityDestroyed, " + actName);
-                        }
-                        for (ModuleBase module : modules) {
-                            module.callbackOnActivityDestroyed(activity);
-                        }
-                    }
-                });
-/*
-                config.application.registerComponentCallbacks(new ComponentCallbacks() {
-                    @Override
-                    public void onConfigurationChanged(Configuration configuration) {
-
-                    }
-
-                    @Override
-                    public void onLowMemory() {
-
-                    }
-                });
- */
+                    };
+                }
+                config.application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks_);
+                config.application.registerComponentCallbacks(componentCallbacks_);
             }
         } else {
             //if this is not the first time we are calling init
@@ -830,6 +934,10 @@ public class Countly {
         COUNTLY_SDK_VERSION_STRING = DEFAULT_COUNTLY_SDK_VERSION_STRING;
         COUNTLY_SDK_NAME = DEFAULT_COUNTLY_SDK_NAME;
 
+        if (config_ != null && config_.application != null) {
+            config_.application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks_);
+            config_.application.unregisterComponentCallbacks(componentCallbacks_);
+        }
         staticInit();
     }
 
@@ -843,104 +951,17 @@ public class Countly {
         }
     }
 
-    /**
-     * Tells the Countly SDK that an Activity has started. Since Android does not have an
-     * easy way to determine when an application instance starts and stops, you must call this
-     * method from every one of your Activity's onStart methods for accurate application
-     * session tracking.
-     *
-     * @throws IllegalStateException if Countly SDK has not been initialized
-     */
-    public synchronized void onStart(Activity activity) {
-        if (isLoggingEnabled()) {
-            String activityName = "NULL ACTIVITY PROVIDED";
-            if (activity != null) {
-                activityName = activity.getClass().getSimpleName();
-            }
-            Log.d(Countly.TAG, "Countly onStart called, name:[" + activityName + "], [" + activityCount_ + "] -> [" + (activityCount_ + 1) + "] activities now open");
-        }
+    /** @deprecated No-op. Activity starts are now tracked automatically */
+    @Deprecated
+    public synchronized void onStart(android.app.Activity activity) { }
 
-        appLaunchDeepLink = false;
-        if (!isInitialized()) {
-            throw new IllegalStateException("init must be called before onStart");
-        }
+    /** @deprecated No-op. Activity stops are now tracked automatically */
+    @Deprecated
+    public synchronized void onStop() { }
 
-        ++activityCount_;
-        if (activityCount_ == 1 && !moduleSessions.manualSessionControlEnabled) {
-            //if we open the first activity
-            //and we are not using manual session control,
-            //begin a session
-
-            moduleSessions.beginSessionInternal();
-        }
-
-        //check if there is an install referrer data
-        String referrer = ReferrerReceiver.getReferrer(context_);
-        if (isLoggingEnabled()) {
-            Log.d(Countly.TAG, "Checking referrer: " + referrer);
-        }
-        if (referrer != null) {
-            connectionQueue_.sendReferrerData(referrer);
-            ReferrerReceiver.deleteReferrer(context_);
-        }
-
-        CrashDetails.inForeground();
-
-        for (ModuleBase module : modules) {
-            module.onActivityStarted(activity);
-        }
-
-        calledAtLeastOnceOnStart = true;
-    }
-
-    /**
-     * Tells the Countly SDK that an Activity has stopped. Since Android does not have an
-     * easy way to determine when an application instance starts and stops, you must call this
-     * method from every one of your Activity's onStop methods for accurate application
-     * session tracking.
-     *
-     * @throws IllegalStateException if Countly SDK has not been initialized, or if
-     * unbalanced calls to onStart/onStop are detected
-     */
-    public synchronized void onStop() {
-        if (isLoggingEnabled()) {
-            Log.d(Countly.TAG, "Countly onStop called, [" + activityCount_ + "] -> [" + (activityCount_ - 1) + "] activities now open");
-        }
-
-        if (!isInitialized()) {
-            throw new IllegalStateException("init must be called before onStop");
-        }
-        if (activityCount_ == 0) {
-            throw new IllegalStateException("must call onStart before onStop");
-        }
-
-        --activityCount_;
-        if (activityCount_ == 0 && !moduleSessions.manualSessionControlEnabled) {
-            // if we don't use manual session control
-            // Called when final Activity is stopped.
-            // Sends an end session event to the server, also sends any unsent custom events.
-            moduleSessions.endSessionInternal(null);
-        }
-
-        CrashDetails.inBackground();
-
-        for (ModuleBase module : modules) {
-            module.onActivityStopped();
-        }
-    }
-
-    public synchronized void onConfigurationChanged(Configuration newConfig) {
-        if (isLoggingEnabled()) {
-            Log.d(Countly.TAG, "Calling [onConfigurationChanged]");
-        }
-        if (!isInitialized()) {
-            throw new IllegalStateException("init must be called before onConfigurationChanged");
-        }
-
-        for (ModuleBase module : modules) {
-            module.onConfigurationChanged(newConfig);
-        }
-    }
+    /** @deprecated No-op. Configuration changes are now tracked automatically */
+    @Deprecated
+    public synchronized void onConfigurationChanged(Configuration newConfig) { }
 
     /**
      * DON'T USE THIS!!!!
@@ -1156,9 +1177,9 @@ public class Countly {
     }
 
     /**
-     * Enable or disable automatic view tracking
+     * Sets automatic view tracking
      *
-     * @param enable boolean for the state of automatic view tracking
+     * @param enable enables automatic view tracking
      * @return Returns link to Countly for call chaining
      * @deprecated use CountlyConfig during init to set this
      */
@@ -1212,7 +1233,7 @@ public class Countly {
             throw new IllegalStateException("Countly.sharedInstance().init must be called before recordView");
         }
 
-        return moduleViews.recordViewInternal(viewName, viewSegmentation);
+        return moduleViews.recordNamedView(viewName, viewSegmentation);
     }
 
     /**
@@ -1639,7 +1660,12 @@ public class Countly {
         return this;
     }
 
-    public static void onCreate(Activity activity) {
+    /** @deprecated
+     * This is now a no-op. Functionality previously in this function is now called automatically for all Activities */
+    @Deprecated
+    public static void onCreate(android.app.Activity activity) { }
+
+    private void onCreateInternal(android.app.Activity activity) {
         Intent launchIntent = activity.getPackageManager().getLaunchIntentForPackage(activity.getPackageName());
 
         if (sharedInstance().isLoggingEnabled()) {
@@ -1762,7 +1788,7 @@ public class Countly {
      * @param callback callback for the star rating dialog "rate" and "dismiss" events
      * @deprecated call this trough 'Countly.sharedInstance().remoteConfig()'
      */
-    public void showStarRating(Activity activity, final CountlyStarRating.RatingCallback callback) {
+    public void showStarRating(android.app.Activity activity, final CountlyStarRating.RatingCallback callback) {
         if (!isInitialized()) {
             if (isLoggingEnabled()) {
                 Log.e(Countly.TAG, "Can't call this function before init has been called");
@@ -2504,7 +2530,7 @@ public class Countly {
      * @return
      * @deprecated use 'Countly.sharedInstance().ratings().showFeedbackPopup'
      */
-    public synchronized Countly showFeedbackPopup(final String widgetId, final String closeButtonText, final Activity activity, final CountlyStarRating.FeedbackRatingCallback feedbackCallback) {
+    public synchronized Countly showFeedbackPopup(final String widgetId, final String closeButtonText, final android.app.Activity activity, final CountlyStarRating.FeedbackRatingCallback feedbackCallback) {
         if (!isInitialized()) {
             throw new IllegalStateException("Countly.sharedInstance().init must be called before showFeedbackPopup");
         }
@@ -2842,7 +2868,21 @@ public class Countly {
         return activityCount_;
     }
 
+    void setActivityCount(int value) {
+        this.activityCount_ = value;
+    }
+
     synchronized boolean getDisableUpdateSessionRequests() {
         return disableUpdateSessionRequests_;
+    }
+
+    <T> String getViewName(T view) {
+        if (view == null) {
+            return "NULL VIEW";
+        }
+        PersistentName ann = view.getClass().getAnnotation(PersistentName.class);
+        String persistentName = ann != null ? ann.value() : moduleViews.persistentNames.get(System.identityHashCode(view));
+        return persistentName != null ? persistentName : automaticTrackingShouldUseShortName ?
+            view.getClass().getSimpleName() : view.getClass().getName();
     }
 }

--- a/sdk/src/main/java/ly/count/android/sdk/Countly.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Countly.java
@@ -2881,7 +2881,7 @@ public class Countly {
             return "NULL VIEW";
         }
         PersistentName ann = view.getClass().getAnnotation(PersistentName.class);
-        String persistentName = ann != null ? ann.value() : moduleViews.persistentNames.get(System.identityHashCode(view));
+        String persistentName = ann != null ? ann.value() : moduleViews.getPersistentNames().get(System.identityHashCode(view));
         return persistentName != null ? persistentName : automaticTrackingShouldUseShortName ?
             view.getClass().getSimpleName() : view.getClass().getName();
     }

--- a/sdk/src/main/java/ly/count/android/sdk/CountlyConfig.java
+++ b/sdk/src/main/java/ly/count/android/sdk/CountlyConfig.java
@@ -144,11 +144,24 @@ public class CountlyConfig {
 
     Map<String, String> metricOverride = null;
 
+    /** @deprecated Use {@link CountlyConfig#CountlyConfig(Application, String, String)} -
+     * an {@link Application} reference is required for automatic lifecycle tracking>} */
+    @Deprecated
     public CountlyConfig() {
     }
 
+    /** @deprecated Use {@link CountlyConfig#CountlyConfig(Application, String, String)} -
+     * an {@link Application} reference is required for automatic lifecycle tracking>} */
+    @Deprecated
     public CountlyConfig(Context context, String appKey, String serverURL) {
         setContext(context);
+        setAppKey(appKey);
+        setServerURL(serverURL);
+    }
+
+    public CountlyConfig(Application application, String appKey, String serverURL) {
+        setApplication(application);
+        setContext(application.getApplicationContext());
         setAppKey(appKey);
         setServerURL(serverURL);
     }

--- a/sdk/src/main/java/ly/count/android/sdk/DoNotTrack.java
+++ b/sdk/src/main/java/ly/count/android/sdk/DoNotTrack.java
@@ -1,0 +1,15 @@
+package ly.count.android.sdk;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Classes annotated with DoNotTrack will not be automatically tracked as views
+ * by Countly. Thus, this annotation can be used as a means to selectively opt-out
+ * of automatic view tracking even when {@link CountlyConfig#enableViewTracking} is true
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DoNotTrack { }

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleAPM.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleAPM.java
@@ -425,7 +425,7 @@ public class ModuleAPM extends ModuleBase {
      * @param activity
      */
     @Override
-    void callbackOnActivityResumed(Activity activity) {
+    void onActivityResumed(Activity activity) {
         if (_cly.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Apm] Calling 'callbackOnActivityResumed', [" + activitiesOpen + "] -> [" + (activitiesOpen + 1) + "]");
         }
@@ -448,7 +448,7 @@ public class ModuleAPM extends ModuleBase {
      * @param activity
      */
     @Override
-    void callbackOnActivityStopped(Activity activity) {
+    void onActivityStopped(Activity activity) {
         if (_cly.isLoggingEnabled()) {
             Log.d(Countly.TAG, "[Apm] Calling 'callbackOnActivityStopped', [" + activitiesOpen + "] -> [" + (activitiesOpen - 1) + "]");
         }

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleBase.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleBase.java
@@ -2,6 +2,7 @@ package ly.count.android.sdk;
 
 import android.app.Activity;
 import android.content.res.Configuration;
+import androidx.annotation.CallSuper;
 
 abstract class ModuleBase {
     Countly _cly;
@@ -22,37 +23,38 @@ abstract class ModuleBase {
     void onConfigurationChanged(Configuration newConfig) {
     }
 
-    /**
-     * Called manually by a countly call from the developer
-     */
+    private <F> void checkFragment(F fragment) {
+        if (!(fragment instanceof android.app.Fragment) && !(fragment instanceof androidx.fragment.app.Fragment)) {
+            throw new IllegalArgumentException("fragment must be an android.app.Fragment or an androidx.fragment.app.Fragment");
+        }
+    }
+
+    @CallSuper
+    <F> void onFragmentStarted(F fragment) {
+        checkFragment(fragment);
+    }
+
+    @CallSuper
+    <F> void onFragmentStopped(F fragment) {
+        checkFragment(fragment);
+    }
+
+    void onActivityCreated(Activity activity) {
+    }
+
     void onActivityStarted(Activity activity) {
     }
 
-    /**
-     * Called manually by a countly call from the developer
-     */
-    void onActivityStopped() {
+    void onActivityResumed(Activity activity) {
     }
 
-    void callbackOnActivityCreated(Activity activity) {
+    void onActivityPaused(Activity activity) {
     }
 
-    void callbackOnActivityStarted(Activity activity) {
+    void onActivityStopped(Activity activity) {
     }
 
-    void callbackOnActivityResumed(Activity activity) {
-    }
-
-    void callbackOnActivityPaused(Activity activity) {
-    }
-
-    void callbackOnActivityStopped(Activity activity) {
-    }
-
-    void callbackOnActivitySaveInstanceState(Activity activity) {
-    }
-
-    void callbackOnActivityDestroyed(Activity activity) {
+    void onActivityDestroyed(Activity activity) {
     }
 
     void deviceIdChanged() {

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleRatings.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleRatings.java
@@ -553,7 +553,7 @@ public class ModuleRatings extends ModuleBase {
     }
 
     @Override
-    void callbackOnActivityResumed(Activity activity) {
+    void onActivityResumed(Activity activity) {
         if (showStarRatingDialogOnFirstActivity) {
             CountlyStore cs = _cly.connectionQueue_.getCountlyStore();
             StarRatingPreferences srp = loadStarRatingPreferences(cs);

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleViews.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleViews.java
@@ -17,9 +17,9 @@ public class ModuleViews extends ModuleBase {
     // identity of object to start time
     @VisibleForTesting Map<Integer, Integer> identityStartTimes = new HashMap<>();
     // identity of object to custom segmentation
-    Map<Integer, Map<String, Object>> identitySegmentation = new HashMap<>();
+    private Map<Integer, Map<String, Object>> identitySegmentation = new HashMap<>();
     // manually added persistent names
-    Map<Integer, String> persistentNames = new HashMap<>();
+    private Map<Integer, String> persistentNames = new HashMap<>();
 
     private boolean firstView = true;
     final static String VIEW_EVENT_KEY = "[CLY]_view";
@@ -116,7 +116,7 @@ public class ModuleViews extends ModuleBase {
         }
     }
 
-    <V> boolean shouldTrack(V view) {
+    private <V> boolean shouldTrack(V view) {
         if (autoTrackingActivityExceptions != null) {
             //noinspection rawtypes
             for (Class autoTrackingActivityException : autoTrackingActivityExceptions) {
@@ -346,6 +346,10 @@ public class ModuleViews extends ModuleBase {
             automaticViewSegmentation = null;
         }
         autoTrackingActivityExceptions = null;
+    }
+
+    public Map<Integer, String> getPersistentNames() {
+        return this.persistentNames;
     }
 
     public class Views {

--- a/sdk/src/main/java/ly/count/android/sdk/PersistentName.java
+++ b/sdk/src/main/java/ly/count/android/sdk/PersistentName.java
@@ -1,0 +1,15 @@
+package ly.count.android.sdk;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Preserves class names for view tracking purposes when using ProGuard/R8
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PersistentName {
+    String value();
+}

--- a/sdk/src/main/java/ly/count/android/sdk/RemoteConfig.java
+++ b/sdk/src/main/java/ly/count/android/sdk/RemoteConfig.java
@@ -1,16 +1,5 @@
 package ly.count.android.sdk;
 
-import android.content.Context;
-import android.util.Log;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.IOException;
-import java.net.URLConnection;
-import java.util.Iterator;
-
 public class RemoteConfig {
 
     public interface RemoteConfigCallback {

--- a/sdk/src/main/java/ly/count/android/sdk/Utils.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Utils.java
@@ -20,7 +20,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import static android.content.Context.UI_MODE_SERVICE;
 


### PR DESCRIPTION
### TLDR
In this PR I add lifecycle observation to the base SDK as a means to reliably and accurately track sessions, foreground/background status, and views. I also add the ability to track multiple views simultaneously, which is necessary for single Activity / multi-Fragment apps or any app in which multiple view components may displayed at the same time.

### Motivations

1. The current implementation of view tracking (one view at a time) is of low value in apps that make heavy use of Fragments as opposed to "one Activity per screen" app architecture. In a "one Activity per app" application, Countly's view tracking is effectively useless. People have [different preferences for app architecture](https://www.youtube.com/watch?v=nP_B5-jrbsY&t=39m50s), and an ideal view tracking implementation would be able to account for most if not all of them. In the below scenario, we should be able to know that SampleActivity, BlueFragment, and RedFragment are all visible at the same time.

![red_blue](https://user-images.githubusercontent.com/2868677/90975469-4be47e00-e4e9-11ea-8ea5-c84e5185307d.png)


2. The current Activity callbacks (onStart/onStop) make false assumptions with respect to the order in which they will be called. This can lead to the following:
    * The SDK thinking it is in the foreground when it is actually in the background, and vice versa
    * Incorrect Activity count
    * Incorrect view name reporting
    * Incorrect view durations
    * Combinations of the above 

  These are all active bugs. Most of the time, these incorrect assumptions will not lead to runtime error. Instead, incorrect information will simply be reported to the backend.

Example:

Let's say ActivityA starts ActivityB. The current implementation assumes that A.onStop will be called before B.onStart. [This is not guaranteed](https://stackoverflow.com/questions/17214452/onstart-of-new-activity-is-called-before-onstop-of-parent). The inverse assumption is also made (that is to say that if B is popped off the back stack, B.onStop will be called before A.onStart) and this is also not guaranteed. You can imagine the chaos that can ensue in terms of view duration, name, activity count, and foreground/background reporting with incorrect assumptions here.

3. Hooking into ActivityLifecycleCallbacks on the Application object inside of Countly.init() can lead to misunderstanding the true state of the app if the users of the SDK call init() outside of Application.onCreate. If the user halts the SDK and re-inits for whatever reason, the SDK may receive unbalanced / lopsided Activity lifecycle callbacks and therefore misunderstand app state.

4. Manual callbacks in onStart/onStop is generally considered bad practice -- 20 other libraries are fighting for space in those Activity callbacks. There are greener pastures with Lifecycle observation.

### Implementation

Instead of a boolean indicating whether or not automatic view tracking is enabled, I introduce the notion of 3 different tracking modes with ```TrackingMode``` (immediately deprecating two of them):

```
public enum TrackingMode {
    /** @deprecated */
    @Deprecated
    MANUAL,
    /** @deprecated */
    @Deprecated
    AUTOMATIC,
    LIFECYCLE
}
```
In ```MANUAL``` and ```AUTOMATIC``` modes, view tracking works like it did before (one view at a time). After calling ```Countly.sharedInstance().views().recordView``` once, any subsequent calls will "close out" the last view and start recording the new one.

In ```LIFECYCLE``` mode, Countly users are expected to instruct Countly to track components with the new public methods ```Countly.sharedInstance().trackLifecycle(LifecycleOwner)``` or ```Countly.sharedInstance().trackLifecycle(LifecycleOwner, Map<String, Object> viewSegmentation)```. Multiple LifecycleOwners can be tracked simultaneously in this mode. **There is no automatic tracking -- users must opt-in in every Activity/Fragment**.

Additionally, multiple named views can be tracked in this mode through the existing ```Countly.sharedInstance().views().recordView``` methods. Because multiple views can be tracked simultaneously, users must manually "close out" tracked views with the new method ```Countly.sharedInstance().views().endViewRecording(String... viewNames)```, which takes a names of the view(s) that the user wants to close out.

Tracking of sessions and foreground/background status has been moved to a ```ProcessLifecycleObserver```, which conveniently calls onStart when the first Activity in an app starts, and onStop when the last Activity stops. **We also cannot miss any state**, as observers are always notified of state changes that occurred even before they ever started observing. The same applies for Activity and Fragment observation.

![Screen Shot 2020-08-23 at 4 02 35 AM](https://user-images.githubusercontent.com/2868677/90976854-8d7b2600-e4f5-11ea-982c-8660f182e841.png)

To live in harmony with ProGuard/R8, I added a simple ```PersistentName``` annotation. Users can annotate their Lifecycle-owning app components with this annotation to ensure that views get unobfuscated names. This is just here to save developers from having to mess with esoteric ProGuard syntax.
```
@PersistentName(name = "MainActivity")
public class MainActivity extends AppCompatActivity {
    @Override
    public void onCreate(Bundle savedInstanceState) {
        super.onCreate(saveInstanceState);
        Countly.sharedInstance().trackLifecycle(this);
        //...
    }
}
```

I'm happy to hop on a call with you guys at your convenience to go over the implementation. Please reach out to me via my work email (I believe you should have it). 