### PR TITLE
Introduce ConnectionInterceptor for individual connection processing

### DIFF
--- a/sdk/src/androidTest/java/ly/count/android/sdk/ConnectionProcessorTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ConnectionProcessorTests.java
@@ -23,6 +23,7 @@ package ly.count.android.sdk;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -32,12 +33,17 @@ import java.net.URLConnection;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static ly.count.android.sdk.UtilsNetworking.sha256Hash;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.isNull;
@@ -269,6 +275,85 @@ public class ConnectionProcessorTests {
         assertTrue(testInputStream1.closed);
         assertTrue(testInputStream2.closed);
         verify(mockURLConnection, times(2)).disconnect();
+    }
+
+    @Test
+    public void testUrlConnectionUsesInterceptor() throws IOException {
+        final String eventData = "blahblahblah";
+        ConnectionInterceptor interceptor = mock(ConnectionInterceptor.class);
+        when(interceptor.intercept(any(HttpURLConnection.class), nullable(byte[].class))).thenAnswer(new Answer<HttpURLConnection>() {
+            @Override public HttpURLConnection answer(InvocationOnMock invocation) throws Throwable {
+                return invocation.getArgument(0, HttpURLConnection.class);
+            }
+        });
+        connectionProcessor.setConnectionInterceptor(interceptor);
+        final URLConnection urlConnection = connectionProcessor.urlConnectionForServerRequest(eventData, null);
+        verify(interceptor).intercept(any(HttpURLConnection.class), nullable(byte[].class));
+        assertEquals(30000, urlConnection.getConnectTimeout());
+        assertEquals(30000, urlConnection.getReadTimeout());
+        assertFalse(urlConnection.getUseCaches());
+        assertTrue(urlConnection.getDoInput());
+        assertFalse(urlConnection.getDoOutput());
+        assertEquals(new URL(connectionProcessor.getServerURL() + "/i?" + eventData + "&checksum256=" + sha256Hash(eventData + null)), urlConnection.getURL());
+    }
+
+    @Test
+    public void testUrlConnectionInterceptorCanSetRequestPropertiesOnGet() throws IOException {
+        final String eventData = "blahblahblah";
+        ConnectionInterceptor interceptor = new ConnectionInterceptor() {
+            @Override public HttpURLConnection intercept(HttpURLConnection connection, byte[] body) {
+                connection.setRequestProperty("Prop", "SomeDynamicHeaderValue");
+                return connection;
+            }
+        };
+        connectionProcessor.setConnectionInterceptor(interceptor);
+        URLConnection conn = connectionProcessor.urlConnectionForServerRequest(eventData, null);
+        assertEquals("SomeDynamicHeaderValue", conn.getRequestProperty("Prop"));
+    }
+
+    @Test
+    public void connectionInterceptorCanSetRequestPropertiesOnPost() throws IOException {
+        // Crash data uses http post
+        final String eventData = "blahblahblah&crash=lol";
+        connectionProcessor = new ConnectionProcessor("https://count.ly/", mockStore, mockDeviceId, null, null, moduleLog);
+        ConnectionInterceptor interceptor = new ConnectionInterceptor() {
+            @Override public HttpURLConnection intercept(HttpURLConnection connection, byte[] body) {
+                connection.setRequestProperty("Prop", "SomeDynamicHeaderValue");
+                return connection;
+            }
+        };
+        connectionProcessor.setConnectionInterceptor(interceptor);
+        URLConnection conn = connectionProcessor.urlConnectionForServerRequest(eventData, null);
+        assertEquals("SomeDynamicHeaderValue", conn.getRequestProperty("Prop"));
+    }
+
+    @Test
+    public void testConnectionInterceptorCanSetRequestPropertiesOnPostPicturePath() throws IOException {
+        File picture = File.createTempFile("IconicFinance", ".png");
+        final String eventData = "picturePath="+picture.getPath();
+        connectionProcessor = new ConnectionProcessor("https://count.ly/", mockStore, mockDeviceId, null, null, moduleLog);
+        ConnectionInterceptor interceptor = new ConnectionInterceptor() {
+            @Override public HttpURLConnection intercept(HttpURLConnection connection, byte[] body) {
+                connection.setRequestProperty("Prop", "SomeDynamicHeaderValue");
+                return connection;
+            }
+        };
+        connectionProcessor.setConnectionInterceptor(interceptor);
+        URLConnection conn = connectionProcessor.urlConnectionForServerRequest(eventData, null);
+        assertEquals("SomeDynamicHeaderValue", conn.getRequestProperty("Prop"));
+    }
+
+    @Test
+    public void testUrlConnectionDoesNotUseInterceptorWhenNotAvailable() throws IOException {
+        final String eventData = "blahblahblah";
+        final URLConnection urlConnection = connectionProcessor.urlConnectionForServerRequest(eventData, null);
+        assertNull(connectionProcessor.getConnectionInterceptor());
+        assertEquals(30000, urlConnection.getConnectTimeout());
+        assertEquals(30000, urlConnection.getReadTimeout());
+        assertFalse(urlConnection.getUseCaches());
+        assertTrue(urlConnection.getDoInput());
+        assertFalse(urlConnection.getDoOutput());
+        assertEquals(new URL(connectionProcessor.getServerURL() + "/i?" + eventData + "&checksum256=" + sha256Hash(eventData + null)), urlConnection.getURL());
     }
 
     private static class TestInputStream2 extends InputStream {

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionInterceptor.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionInterceptor.java
@@ -1,0 +1,18 @@
+package ly.count.android.sdk;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Interface to intercept Countly requests
+ */
+public interface ConnectionInterceptor {
+
+    /**
+     * This is called for each request which is send by Countly
+     *
+     * @param connection The connection which is about to be send
+     * @param body Body of the connection, null for GET requests
+     * @return HttpURLConnection which is used for connection
+     */
+    HttpURLConnection intercept(HttpURLConnection connection, byte[] body);
+}

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
@@ -51,6 +51,7 @@ public class ConnectionQueue {
     private Future<?> connectionProcessorFuture_;
     private DeviceId deviceId_;
     private SSLContext sslContext_;
+    private ConnectionInterceptor connectionInterceptor_;
 
     private Map<String, String> requestHeaderCustomValues;
     Map<String, String> metricOverride = null;
@@ -652,8 +653,14 @@ public class ConnectionQueue {
         }
     }
 
+    public void setConnectionInterceptor(ConnectionInterceptor interceptor) {
+        this.connectionInterceptor_ = interceptor;
+    }
+
     public ConnectionProcessor createConnectionProcessor() {
-        return new ConnectionProcessor(getServerURL(), store_, deviceId_, sslContext_, requestHeaderCustomValues, L);
+        ConnectionProcessor processor = new ConnectionProcessor(getServerURL(), store_, deviceId_, sslContext_, requestHeaderCustomValues, L);
+        processor.setConnectionInterceptor(connectionInterceptor_);
+        return processor;
     }
 
     public boolean queueContainsTemporaryIdItems() {

--- a/sdk/src/main/java/ly/count/android/sdk/Countly.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Countly.java
@@ -884,6 +884,16 @@ public class Countly {
     }
 
     /**
+     * Sets an interceptor which can be used to run custom connection processing for each network requests.
+     * This is useful to add dynamic headers for each request.
+     *
+     * @param interceptor Gets an HttpURLConnection and returns a new HttpURLConnection
+     */
+    public void setConnectionInterceptor(ConnectionInterceptor interceptor) {
+        connectionQueue_.setConnectionInterceptor(interceptor);
+    }
+
+    /**
      * Changes current device id type to the one specified in parameter. Closes current session and
      * reopens new one with new id. Doesn't merge user profiles on the server
      *


### PR DESCRIPTION
## Motivation
Currently, it is only possible to set static http header values once. It is not possible to add header values which change with each network request. 
We have the need to add headers which change with each request, because we sign each request (request method, request body and some other meta information) with a timestamp in our app. 

## What changed
Similarly to Okhttp, this introduces an interceptor interface `ConnectionInterceptor` to process each connection, i.e. add custom header which change with each request. It can be set at the beginning and will be called for each network request.

## Example
```java
ConnectionInterceptor interceptor = new ConnectionInterceptor() {
    @Override public HttpURLConnection intercept(HttpURLConnection connection, byte[] body) {
        connection.setRequestProperty("Prop", new Date().toString() + " super secret signature");
        return connection;
    }
};
Countly.sharedInstance().setConnectionInterceptor(interceptor)
```