### PR TITLE
Fixes Implicit PendingIntent Issue

### DIFF
--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -8,6 +8,11 @@
 
   <application>
     <uses-library android:name="android.test.runner" />
+    <receiver android:name=".messaging.CountlyPush$NotificationBroadcastReceiver" android:exported="false">
+      <intent-filter>
+        <action android:name="ly.count.android.sdk.CountlyPush.SECURE_NOTIFICATION_BROADCAST" />
+      </intent-filter>
+    </receiver>
   </application>
 
 </manifest>

--- a/sdk/src/main/java/ly/count/android/sdk/messaging/CountlyPush.java
+++ b/sdk/src/main/java/ly/count/android/sdk/messaging/CountlyPush.java
@@ -71,7 +71,7 @@ public class CountlyPush {
 
     public static boolean useAdditionalIntentRedirectionChecks = false;
 
-    private static BroadcastReceiver notificationActionReceiver = null, consentReceiver = null;
+    private static BroadcastReceiver consentReceiver = null;
 
     /**
      * Message object encapsulating data in {@code RemoteMessage} sent from Countly server.
@@ -445,7 +445,8 @@ public class CountlyPush {
             return Boolean.FALSE;
         }
 
-        Intent broadcast = new Intent(SECURE_NOTIFICATION_BROADCAST);
+        Intent broadcast = new Intent(SECURE_NOTIFICATION_BROADCAST, null, context.getApplicationContext(), NotificationBroadcastReceiver.class);
+        broadcast.setPackage(context.getApplicationContext().getPackageName());
         broadcast.putExtra(EXTRA_INTENT, actionIntent(context, notificationIntent, msg, 0));
 
         final Notification.Builder builder = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ? new Notification.Builder(context.getApplicationContext(), CHANNEL_ID) : new Notification.Builder(context.getApplicationContext()))
@@ -462,17 +463,18 @@ public class CountlyPush {
         }
 
         builder.setAutoCancel(true)
-            .setContentIntent(PendingIntent.getBroadcast(context, msg.hashCode(), broadcast, 0));
+            .setContentIntent(PendingIntent.getBroadcast(context, msg.hashCode(), broadcast, Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0));
 
         builder.setStyle(new Notification.BigTextStyle().bigText(msg.message()).setBigContentTitle(msg.title()));
 
         for (int i = 0; i < msg.buttons().size(); i++) {
             Button button = msg.buttons().get(i);
 
-            broadcast = new Intent(SECURE_NOTIFICATION_BROADCAST);
+            broadcast = new Intent(SECURE_NOTIFICATION_BROADCAST, null, context.getApplicationContext(), NotificationBroadcastReceiver.class);
+            broadcast.setPackage(context.getApplicationContext().getPackageName());
             broadcast.putExtra(EXTRA_INTENT, actionIntent(context, notificationIntent, msg, i + 1));
 
-            builder.addAction(button.icon(), button.title(), PendingIntent.getBroadcast(context, msg.hashCode() + i + 1, broadcast, 0));
+            builder.addAction(button.icon(), button.title(), PendingIntent.getBroadcast(context, msg.hashCode() + i + 1, broadcast, Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0));
         }
 
         if (msg.sound() != null) {
@@ -786,11 +788,6 @@ public class CountlyPush {
             application.registerActivityLifecycleCallbacks(callbacks);
 
             IntentFilter filter = new IntentFilter();
-            filter.addAction(SECURE_NOTIFICATION_BROADCAST);
-            notificationActionReceiver = new NotificationBroadcastReceiver();
-            application.registerReceiver(notificationActionReceiver, filter, application.getPackageName() + COUNTLY_BROADCAST_PERMISSION_POSTFIX, null);
-
-            filter = new IntentFilter();
             filter.addAction(Countly.CONSENT_BROADCAST);
             consentReceiver = new ConsentBroadcastReceiver();
             application.registerReceiver(consentReceiver, filter, application.getPackageName() + COUNTLY_BROADCAST_PERMISSION_POSTFIX, null);


### PR DESCRIPTION
More information about the issue can be found here: [https://support.google.com/faqs/answer/10437428](https://support.google.com/faqs/answer/10437428)

When creating the BroadcastIntent in the displayNotification method, we now follow all the recommendations provided by Google in the above help center article.

Unfortunately according to [this](https://stackoverflow.com/a/31632697) Stackoverflow answer, which links to [this](http://streamingcon.blogspot.com/2014/04/dynamic-broadcastreceiver-registration.html) blog post it's not possible to use an explicit Intent when dynamically registering the broadcast receiver.

For that reason I registered the receiver in the Manifest with the necessary filter as I wasn't able to find out why you went for a dynamic registering of the receiver.

When creating an update with that fix included, we were able to get our update approved by Google. So this definitely fixes the issue and I hope it doesn't break something else :)