### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,12 @@
 # org.gradle.parallel=true
 #Fri Sep 27 10:41:50 EEST 2019
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options="-Xmx2048M"
+org.gradle.caching = true
+org.gradle.parallel = true
+org.gradle.configureondemand = true
+# should be enabled in the future. Needs Gradle 6.5
+# org.gradle.vfs.watch = true 
+
 android.useAndroidX=true
 android.enableJetifier=true
 
@@ -35,7 +41,3 @@ signing.secretKeyRingFile=xxx
 
 mavenCentralRepositoryUsername=xxx
 mavenCentralRepositoryPassword=xxx
-org.gradle.caching = true
-org.gradle.parallel = true
-org.gradle.configureondemand = true
-org.gradle.vfs.watch = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Fri Sep 27 10:41:50 EEST 2019
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options="-Xmx2048M"
 android.useAndroidX=true
 android.enableJetifier=true
 
@@ -35,3 +35,7 @@ signing.secretKeyRingFile=xxx
 
 mavenCentralRepositoryUsername=xxx
 mavenCentralRepositoryPassword=xxx
+org.gradle.caching = true
+org.gradle.parallel = true
+org.gradle.configureondemand = true
+org.gradle.vfs.watch = true


### PR DESCRIPTION

[Parallel builds](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:parallel_execution). This project contains multiple modules. Parallel builds can improve the build speed by executing tasks in parallel. We can enable this feature by setting `org.gradle.parallel=true`.

[File system watching](https://blog.gradle.org/introducing-file-system-watching). Since Gradle 6.5, File system watching was introduced which can help to avoid unnecessary I/O. This feature is the default since 7.0. For an older version, we can enable this feature by setting `org.gradle.vfs.watch=true`.

[Configuration on demand](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand). Configuration on demand tells Gradle to configure modules that only are relevant to the requested tasks instead of configuring all of them. We can enable this feature by setting `org.gradle.configureondemand=true`.

[gradle caching](https://docs.gradle.org/current/userguide/build_cache.html). Shared caches can reduce the number of tasks you need to execute by reusing outputs already generated elsewhere. This can significantly decrease build times. We can enable this feature by setting `org.gradle.caching=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
