### PR TITLE
Add new consent category for metrics data

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionQueue.java
@@ -607,8 +607,8 @@ class ConnectionQueue implements RequestQueueProvider {
             + "&method=fetch_remote_config"
             + "&device_id=" + UtilsNetworking.urlEncodeString(deviceId_.getCurrentId());
 
-        if (consentProvider.getConsent(Countly.CountlyFeatureNames.sessions)) {
-            //add session data if consent given
+        if (consentProvider.getConsent(Countly.CountlyFeatureNames.metrics) || consentProvider.getConsent(Countly.CountlyFeatureNames.sessions)) {
+            //add metrics data if consent given
             data += "&metrics=" + DeviceInfo.getMetrics(context_, metricOverride);
         }
 

--- a/sdk/src/main/java/ly/count/android/sdk/Countly.java
+++ b/sdk/src/main/java/ly/count/android/sdk/Countly.java
@@ -202,6 +202,7 @@ public class Countly {
     protected CountlyConfig config_ = null;
 
     public static class CountlyFeatureNames {
+        public static final String metrics = "metrics";
         public static final String sessions = "sessions";
         public static final String events = "events";
         public static final String views = "views";


### PR DESCRIPTION
Metrics data are sent only if session consent is given. If you don't want to track the session, it's impossible to get the metrics data.

This MR create a new category called "metrics" that used only to send metrics data. For backwards compatibility, metrics data are also sent if you give consent for "session".

Feel free to make any changes or just capture the idea behind this MR.