### PR TITLE
Remove BROADCAST_CLOSE_SYSTEM_DIALOGS from sdk

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-permission android:name="${applicationId}.CountlyPush.BROADCAST_PERMISSION" />
-    <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" />
+    <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" android:maxSdkVersion="30" />
+    
 
     <application
         android:name=".App"

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -17,6 +17,4 @@
       android:name="${applicationId}.CountlyPush.BROADCAST_PERMISSION"
       android:protectionLevel="signature" />
 
-  <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" />
-
 </manifest>


### PR DESCRIPTION
* Removed BROADCAST_CLOSE_SYSTEM_DIALOGS permission from the SDK's manifest. If this permission is merged into the manifest of a system app on Android 12, it can prevent the app from starting if BROADCAST_CLOSE_SYSTEM_DIALOGS isn't in the app's privapp-permissions file
* Added the android:maxSdkVersion="30" attribute to the BROADCAST_CLOSE_SYSTEM_DIALOGS permission in the sample app's manifest, so that devices running Android 12 and up don't request the deprecated permission

In your docs, it would probably be best to just recommend this permission (with the maxSdkVersion attribute) for Countly users that are utilizing CountlyPush. For those not using CountlyPush, it's an aggressive permission that isn't used.

https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs