### PR TITLE
Use metric overrides in crash details

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/DeviceInfo.java
+++ b/sdk/src/main/java/ly/count/android/sdk/DeviceInfo.java
@@ -226,13 +226,7 @@ class DeviceInfo {
         return "mobile";
     }
 
-    /**
-     * Returns a URL-encoded JSON string containing the device metrics
-     * to be associated with a begin session event.
-     * See the following link for more info:
-     * https://count.ly/resources/reference/server-api
-     */
-    static String getMetrics(final Context context, final Map<String, String> metricOverride) {
+    protected static JSONObject getMetricsJson(final Context context, final Map<String, String> metricOverride) {
         final JSONObject json = new JSONObject();
 
         fillJSONIfValuesNotEmpty(json,
@@ -270,6 +264,17 @@ class DeviceInfo {
                 }
             }
         }
+        return json;
+    }
+
+    /**
+     * Returns a URL-encoded JSON string containing the device metrics
+     * to be associated with a begin session event.
+     * See the following link for more info:
+     * https://count.ly/resources/reference/server-api
+     */
+    static String getMetrics(final Context context, final Map<String, String> metricOverride) {
+        JSONObject json = DeviceInfo.getMetricsJson(context, metricOverride);
 
         String result = json.toString();
 

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleCrash.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleCrash.java
@@ -28,6 +28,9 @@ public class ModuleCrash extends ModuleBase {
     //interface for SDK users
     final Crashes crashesInterface;
 
+    @Nullable
+    Map<String, String> metricOverride = null;
+
     ModuleCrash(Countly cly, CountlyConfig config) {
         super(cly, config);
         L.v("[ModuleCrash] Initialising");
@@ -37,6 +40,8 @@ public class ModuleCrash extends ModuleBase {
         recordAllThreads = config.recordAllThreadsWithCrash;
 
         setCustomCrashSegmentsInternal(config.customCrashSegment);
+
+        metricOverride = config.metricOverride;
 
         crashesInterface = new Crashes();
     }
@@ -131,7 +136,13 @@ public class ModuleCrash extends ModuleBase {
             error = error.substring(0, Math.min(20000, error.length()));
         }
 
-        final String crashData = CrashDetails.getCrashData(_cly.context_, error, nonfatal, isNativeCrash, CrashDetails.getLogs(), combinedSegmentationValues);
+        final String crashData;
+        if (metricOverride != null) {
+            crashData = CrashDetails.getCrashData(_cly.context_, error, nonfatal, isNativeCrash, CrashDetails.getLogs(), combinedSegmentationValues, metricOverride);
+        } else {
+            crashData = CrashDetails.getCrashData(_cly.context_, error, nonfatal, isNativeCrash, CrashDetails.getLogs(), combinedSegmentationValues);
+        }
+
 
         requestQueueProvider.sendCrashReport(crashData, nonfatal);
     }


### PR DESCRIPTION
See https://github.com/Countly/countly-sdk-android/issues/162

Didn't write tests but can if you approve the API change. No breaking of public or private API (added overrides only). Some functions in CrashDetails could also be moved to DeviceInfo for consistency, but I didn't move them in case you want them to stay put. I *did* get rid of CrashDetails#getManufacturer() in  as it was redundant with DeviceInfo#getManufacturer()