### PR TITLE
Add detailed timed logs to CP

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
@@ -110,19 +110,22 @@ public class ConnectionProcessor implements Runnable {
             if (!hasPicturePath) {
                 String checksum = UtilsNetworking.sha256Hash(requestData + requestInfoProvider_.getRequestSalt());
                 requestData += "&checksum256=" + checksum;
-                L.v("[Connection Processor] The following checksum was added:[" + checksum + "]");
+                L.v("[ConnectionProcessor] The following checksum was added:[" + checksum + "]");
                 approximateDateSize += requestData.length(); // add request data to the estimated data size
             }
         } else {
             urlStr += "?" + requestData;
             String checksum = UtilsNetworking.sha256Hash(requestData + requestInfoProvider_.getRequestSalt());
             urlStr += "&checksum256=" + checksum;
-            L.v("[Connection Processor] The following checksum was added:[" + checksum + "]");
+            L.v("[ConnectionProcessor] The following checksum was added:[" + checksum + "]");
         }
         approximateDateSize += urlStr.length();
 
         final URL url = new URL(urlStr);
         final HttpURLConnection conn;
+
+        long pccTsOpenURLConnection = UtilsTime.getNanoTime();
+
         if (Countly.publicKeyPinCertificates == null && Countly.certificatePinCertificates == null) {
             conn = (HttpURLConnection) url.openConnection();
         } else {
@@ -130,6 +133,15 @@ public class ConnectionProcessor implements Runnable {
             c.setSSLSocketFactory(sslContext_.getSocketFactory());
             conn = c;
         }
+
+        long openUrlConnectionTime = UtilsTime.getNanoTime() - pccTsOpenURLConnection;
+        L.d("[ConnectionProcessor] urlConnectionForServerRequest, TIMING Open URL connection took:[" + openUrlConnectionTime / 1000000.0d + "] ms");
+        if (pcc != null) {
+            pcc.TrackCounterTimeNs("ConnectionProcessorUrlConnectionForServerRequest_01_OpenURLConnection", openUrlConnectionTime);
+        }
+
+        long pccTsConfigureConnection = UtilsTime.getNanoTime();
+
         conn.setConnectTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS);
         conn.setReadTimeout(READ_TIMEOUT_IN_MILLISECONDS);
         conn.setUseCaches(false);
@@ -138,7 +150,7 @@ public class ConnectionProcessor implements Runnable {
 
         if (requestHeaderCustomValues_ != null) {
             //if there are custom header values, add them
-            L.v("[Connection Processor] Adding [" + requestHeaderCustomValues_.size() + "] custom header fields");
+            L.v("[ConnectionProcessor] Adding [" + requestHeaderCustomValues_.size() + "] custom header fields");
             for (Map.Entry<String, String> entry : requestHeaderCustomValues_.entrySet()) {
                 String key = entry.getKey();
                 String value = entry.getValue();
@@ -148,7 +160,7 @@ public class ConnectionProcessor implements Runnable {
             }
         }
 
-        L.v("[Connection Processor] Has picturePath [" + hasPicturePath + "]");
+        L.v("[ConnectionProcessor] Has picturePath [" + hasPicturePath + "]");
 
         if (hasPicturePath) {
             String boundary = Long.toHexString(System.currentTimeMillis());// Just generate some unique random value as the boundary
@@ -192,10 +204,18 @@ public class ConnectionProcessor implements Runnable {
                 writer.close();
                 os.close();
             } else {
-                L.v("[Connection Processor] Using HTTP GET");
+                L.v("[ConnectionProcessor] Using HTTP GET");
                 conn.setDoOutput(false);
             }
         }
+
+        long configureConnectionTime = UtilsTime.getNanoTime() - pccTsConfigureConnection;
+        L.d("[ConnectionProcessor] urlConnectionForServerRequest, TIMING Configure connection took:[" + configureConnectionTime / 1000000.0d + "] ms");
+        if (pcc != null) {
+            pcc.TrackCounterTimeNs("ConnectionProcessorUrlConnectionForServerRequest_02_ConfigureConnection", configureConnectionTime);
+        }
+
+        long pccTsStartHeaderFieldSize = UtilsTime.getNanoTime();
 
         //calculating header field size
         try {
@@ -215,7 +235,13 @@ public class ConnectionProcessor implements Runnable {
             L.e("[ConnectionProcessor] urlConnectionForServerRequest, exception while calculating header field size: " + e);
         }
 
-        L.v("[Connection Processor] Using HTTP POST: [" + usingHttpPost + "] forced:[" + requestInfoProvider_.isHttpPostForced()
+        long headerFieldSizeTime = UtilsTime.getNanoTime() - pccTsStartHeaderFieldSize;
+        L.d("[ConnectionProcessor] urlConnectionForServerRequest, TIMING Header field size calculation took:[" + headerFieldSizeTime / 1000000.0d + "] ms");
+        if (pcc != null) {
+            pcc.TrackCounterTimeNs("ConnectionProcessorUrlConnectionForServerRequest_03_HeaderFieldSize", headerFieldSizeTime);
+        }
+
+        L.v("[ConnectionProcessor] Using HTTP POST: [" + usingHttpPost + "] forced:[" + requestInfoProvider_.isHttpPostForced()
             + "] length:[" + (requestData.length() >= 2048) + "] crash:[" + requestData.contains("&crash=") + "] | Approx data size: [" + approximateDateSize + " B]");
         return conn;
     }
@@ -279,51 +305,41 @@ public class ConnectionProcessor implements Runnable {
 
     @Override
     public void run() {
+        long wholeQueueStart = UtilsTime.getNanoTime();
         while (true) {
             long pccTsStartWholeQueue = 0L;
             long pccTsStartOnlyInternet = 0L;
             long pccTsStartTempIdCheck = 0L;
             long pccTsStartEndpointCheck = 0L;
             long pccTsStartOldRCheck = 0L;
-            long pccTsStartGetURLConnection = 0L;
+            long pccTsStartGetURLConnection;
             long pccTsStartDeviceIDOverride = 0L;
             long pccTsStartRemainingRequests = 0L;
-            long pccTsStartHandlingResponse = 0L;
+            long pccTsReadingStream;
+            long pccTsStartHandlingResponse;
 
             if (!configProvider_.getNetworkingEnabled()) {
-                L.w("[Connection Processor] run, Networking config is disabled, request queue skipped");
+                L.w("[ConnectionProcessor] run, Networking config is disabled, request queue skipped");
                 break;
             }
 
             //------------------------
-
-            if (pcc != null) {
-                pccTsStartWholeQueue = UtilsTime.getNanoTime();
-            }
-
             // get stored requests
             final String[] storedRequests = storageProvider_.getRequests();
             int storedRequestCount = storedRequests == null ? 0 : storedRequests.length;
 
-            if (L.logEnabled()) {
-                String msg = "[Connection Processor] Starting to run, there are [" + storedRequestCount + "] requests stored";
-                if (storedRequestCount == 0) {
-                    L.v(msg);
-                } else {
-                    L.i(msg);
-                }
-            }
-
-            if (storedRequests == null || storedRequestCount == 0) {
-                L.i("[Connection Processor] No requests in the queue, request queue skipped");
+            if (storedRequestCount == 0) {
+                L.i("[ConnectionProcessor] No requests in the queue, request queue skipped");
                 // currently no data to send, we are done for now
                 break;
             }
 
+            L.i("[ConnectionProcessor] Starting to run, there are [" + storedRequestCount + "] requests stored");
+
             if (deviceIdProvider_.getDeviceId() == null) {
                 // When device ID is supplied by OpenUDID or by Google Advertising ID.
                 // In some cases it might take time for them to initialize. So, just wait for it.
-                L.i("[Connection Processor] No Device ID available yet, skipping request " + storedRequests[0]);
+                L.i("[ConnectionProcessor] No Device ID available yet, skipping request " + storedRequests[0]);
                 break;
             }
 
@@ -341,8 +357,8 @@ public class ConnectionProcessor implements Runnable {
                 pccTsStartOldRCheck = UtilsTime.getNanoTime();
             }
 
-            L.i("[Connection Processor] Checking if the request is older than:[" + requestInfoProvider_.getRequestDropAgeHours() + "] hours");
-            boolean isRequestOld = Utils.isRequestTooOld(requestData, requestInfoProvider_.getRequestDropAgeHours(), "[Connection Processor]", L);
+            L.i("[ConnectionProcessor] Checking if the request is older than:[" + requestInfoProvider_.getRequestDropAgeHours() + "] hours");
+            boolean isRequestOld = Utils.isRequestTooOld(requestData, requestInfoProvider_.getRequestDropAgeHours(), "[ConnectionProcessor]", L);
 
             if (pcc != null) {
                 pcc.TrackCounterTimeNs("ConnectionProcessorRun_02_NetworkOldReq", UtilsTime.getNanoTime() - pccTsStartOldRCheck);
@@ -363,7 +379,7 @@ public class ConnectionProcessor implements Runnable {
                 //the internally set id is the temporary one
 
                 //abort and wait for exiting temporary mode
-                L.i("[Connection Processor] Temporary ID detected, stalling requests. Id override:[" + containsTemporaryIdOverride + "], tmp id tag:[" + containsTemporaryId + "], temp ID set:[" + deviceIdProvider_.isTemporaryIdEnabled() + "]");
+                L.i("[ConnectionProcessor] Temporary ID detected, stalling requests. Id override:[" + containsTemporaryIdOverride + "], tmp id tag:[" + containsTemporaryId + "], temp ID set:[" + deviceIdProvider_.isTemporaryIdEnabled() + "]");
                 break;
             }
             if (pcc != null) {
@@ -383,10 +399,10 @@ public class ConnectionProcessor implements Runnable {
             if (extractionResult[1] != null) {
                 requestData = extractionResult[0];
 
-                if (!extractionResult[1].equals("")) {
+                if (!extractionResult[1].isEmpty()) {
                     customEndpoint = extractionResult[1];
                 }
-                L.v("[Connection Processor] Custom end point detected for the request:[" + customEndpoint + "]");
+                L.v("[ConnectionProcessor] Custom end point detected for the request:[" + customEndpoint + "]");
             }
 
             if (pcc != null) {
@@ -427,7 +443,7 @@ public class ConnectionProcessor implements Runnable {
 
                         deviceIdChange = false;
 
-                        L.d("[Connection Processor] Provided device_id is the same as the previous one used, nothing will be merged");
+                        L.d("[ConnectionProcessor] Provided device_id is the same as the previous one used, nothing will be merged");
                     } else {
                         //new device_id provided, make sure it will be merged
                         requestData = requestData + "&old_device_id=" + UtilsNetworking.urlEncodeString(deviceIdProvider_.getDeviceId());
@@ -465,22 +481,24 @@ public class ConnectionProcessor implements Runnable {
                 URLConnection conn = null;
                 InputStream connInputStream = null;
                 try {
-                    if (pcc != null) {
-                        pccTsStartGetURLConnection = UtilsTime.getNanoTime();
-                    }
+                    pccTsStartGetURLConnection = UtilsTime.getNanoTime();
 
                     // initialize and open connection
                     conn = urlConnectionForServerRequest(requestData, customEndpoint);
+                    long setupServerRequestTime = UtilsTime.getNanoTime() - pccTsStartGetURLConnection;
+                    L.d("[ConnectionProcessor] run, TIMING Setup server request took:[" + setupServerRequestTime / 1000000.0d + "] ms");
                     if (pcc != null) {
-                        pcc.TrackCounterTimeNs("ConnectionProcessorRun_07_SetupServerRequest", UtilsTime.getNanoTime() - pccTsStartGetURLConnection);
+                        pcc.TrackCounterTimeNs("ConnectionProcessorRun_07_SetupServerRequest", setupServerRequestTime);
                         pccTsStartOnlyInternet = UtilsTime.getNanoTime();
                     }
                     conn.connect();
 
                     if (pcc != null) {
                         pcc.TrackCounterTimeNs("ConnectionProcessorRun_08_NetworkOnlyInternet", UtilsTime.getNanoTime() - pccTsStartOnlyInternet);
-                        pccTsStartHandlingResponse = UtilsTime.getNanoTime();
                     }
+
+                    pccTsStartHandlingResponse = UtilsTime.getNanoTime();
+                    pccTsReadingStream = UtilsTime.getNanoTime();
 
                     int responseCode = 0;
                     String responseString = "";
@@ -499,14 +517,19 @@ public class ConnectionProcessor implements Runnable {
                         responseString = Utils.inputStreamToString(connInputStream);
                     }
 
-                    L.d("[Connection Processor] code:[" + responseCode + "], response:[" + responseString + "], response size:[" + responseString.length() + " B], request: " + requestData + ", url: " + serverURL_);
+                    long readingStreamTime = UtilsTime.getNanoTime() - pccTsReadingStream;
+                    L.d("[ConnectionProcessor] code:[" + responseCode + "], response:[" + responseString + "], response size:[" + responseString.length() + " B], request: " + requestData + ", url: " + serverURL_ + ", Reading stream took:[" + readingStreamTime / 1000000.0d + "] ms");
+
+                    if (pcc != null) {
+                        pcc.TrackCounterTimeNs("ConnectionProcessorRun_13_ReadingStream", readingStreamTime);
+                    }
 
                     final RequestResult rRes;
 
                     if (responseCode >= 200 && responseCode < 300) {
 
                         if (responseString.isEmpty()) {
-                            L.v("[Connection Processor] Response was empty, will retry");
+                            L.v("[ConnectionProcessor] Response was empty, will retry");
                             rRes = RequestResult.RETRY;
                         } else {
                             JSONObject jsonObject;
@@ -515,37 +538,37 @@ public class ConnectionProcessor implements Runnable {
                             } catch (JSONException ex) {
                                 //failed to parse, so not a valid json
                                 jsonObject = null;
-                                L.e("[Connection Processor] Failed to parse response [" + responseString + "].");
+                                L.e("[ConnectionProcessor] Failed to parse response [" + responseString + "].");
                             }
 
                             if (jsonObject == null) {
                                 //received unparseable response, retrying
-                                L.v("[Connection Processor] Response was a unknown, will retry");
+                                L.v("[ConnectionProcessor] Response was a unknown, will retry");
                                 rRes = RequestResult.RETRY;
                             } else {
                                 if (jsonObject.has("result")) {
                                     //contains result entry
-                                    L.v("[Connection Processor] Response was a success");
+                                    L.v("[ConnectionProcessor] Response was a success");
                                     rRes = RequestResult.OK;
                                 } else {
-                                    L.v("[Connection Processor] Response does not contain 'result', will retry");
+                                    L.v("[ConnectionProcessor] Response does not contain 'result', will retry");
                                     rRes = RequestResult.RETRY;
                                 }
                             }
                         }
                     } else if (responseCode >= 300 && responseCode < 400) {
                         //assume redirect
-                        L.d("[Connection Processor] Encountered redirect, will retry");
+                        L.d("[ConnectionProcessor] Encountered redirect, will retry");
                         rRes = RequestResult.RETRY;
                     } else if (responseCode == 400 || responseCode == 404) {
-                        L.w("[Connection Processor] Bad request, will still retry");
+                        L.w("[ConnectionProcessor] Bad request, will still retry");
                         rRes = RequestResult.RETRY;
                     } else if (responseCode > 400) {
                         //server down, try again later
-                        L.d("[Connection Processor] Server is down, will retry");
+                        L.d("[ConnectionProcessor] Server is down, will retry");
                         rRes = RequestResult.RETRY;
                     } else {
-                        L.d("[Connection Processor] Bad response code, will retry");
+                        L.d("[ConnectionProcessor] Bad response code, will retry");
                         rRes = RequestResult.RETRY;
                     }
 
@@ -560,12 +583,12 @@ public class ConnectionProcessor implements Runnable {
                             if (newId != null && !newId.isEmpty()) {
                                 deviceIdProvider_.getDeviceIdInstance().changeToCustomId(newId);//todo needs to be refactored
                             } else {
-                                L.e("[Connection Processor] Failed to change device ID with merging because the new ID was empty or null. [" + newId + "]");
+                                L.e("[ConnectionProcessor] Failed to change device ID with merging because the new ID was empty or null. [" + newId + "]");
                             }
                         }
 
                         if (deviceIdChange || deviceIdOverride) {
-                            L.v("[Connection Processor] Device ID changed, change:[" + deviceIdChange + "] | override:[" + deviceIdOverride + "]");
+                            L.v("[ConnectionProcessor] Device ID changed, change:[" + deviceIdChange + "] | override:[" + deviceIdOverride + "]");
                             Countly.sharedInstance().notifyDeviceIdChange();//todo needs to be removed at some point
                         }
                     } else {
@@ -581,7 +604,7 @@ public class ConnectionProcessor implements Runnable {
                         break;
                     }
                 } catch (Exception e) {
-                    L.d("[Connection Processor] Got exception while trying to submit request data: [" + requestData + "] [" + e + "]");
+                    L.d("[ConnectionProcessor] Got exception while trying to submit request data: [" + requestData + "] [" + e + "]");
                     // if exception occurred, stop processing, let next tick take care of retrying
                     if (pcc != null) {
                         pcc.TrackCounterTimeNs("ConnectionProcessorRun_11_NetworkWholeQueueException", UtilsTime.getNanoTime() - pccTsStartWholeQueue);
@@ -600,15 +623,17 @@ public class ConnectionProcessor implements Runnable {
                         ((HttpURLConnection) conn).disconnect();
                     }
                 }
+                long handlingResponseTime = UtilsTime.getNanoTime() - pccTsStartHandlingResponse;
+                L.d("[ConnectionProcessor] run, TIMING Handling response took:[" + handlingResponseTime / 1000000.0d + "] ms");
                 if (pcc != null) {
-                    pcc.TrackCounterTimeNs("ConnectionProcessorRun_09_HandlingResponse", UtilsTime.getNanoTime() - pccTsStartHandlingResponse);
+                    pcc.TrackCounterTimeNs("ConnectionProcessorRun_09_HandlingResponse", handlingResponseTime);
                 }
             } else {
                 //device is identified as a app crawler and nothing is sent to the server
                 if (isRequestOld) {
-                    L.i("[Connection Processor] request is too old, removing request " + originalRequest);
+                    L.i("[ConnectionProcessor] request is too old, removing request " + originalRequest);
                 } else {
-                    L.i("[Connection Processor] Device identified as an app crawler, removing request " + originalRequest);
+                    L.i("[ConnectionProcessor] Device identified as an app crawler, removing request " + originalRequest);
                 }
 
                 //remove stored data
@@ -619,6 +644,8 @@ public class ConnectionProcessor implements Runnable {
                 pcc.TrackCounterTimeNs("ConnectionProcessorRun_10_NetworkWholeQueue", UtilsTime.getNanoTime() - pccTsStartWholeQueue);
             }
         }
+        long wholeQueueTime = UtilsTime.getNanoTime() - wholeQueueStart;
+        L.d("[ConnectionProcessor] run, TIMING Whole queue took:[" + wholeQueueTime / 1000000.0d + "] ms");
     }
 
     String getServerURL() {

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
@@ -110,14 +110,14 @@ public class ConnectionProcessor implements Runnable {
             if (!hasPicturePath) {
                 String checksum = UtilsNetworking.sha256Hash(requestData + requestInfoProvider_.getRequestSalt());
                 requestData += "&checksum256=" + checksum;
-                L.v("[ConnectionProcessor] The following checksum was added:[" + checksum + "]");
+                L.v("[Connection Processor] The following checksum was added:[" + checksum + "]");
                 approximateDateSize += requestData.length(); // add request data to the estimated data size
             }
         } else {
             urlStr += "?" + requestData;
             String checksum = UtilsNetworking.sha256Hash(requestData + requestInfoProvider_.getRequestSalt());
             urlStr += "&checksum256=" + checksum;
-            L.v("[ConnectionProcessor] The following checksum was added:[" + checksum + "]");
+            L.v("[Connection Processor] The following checksum was added:[" + checksum + "]");
         }
         approximateDateSize += urlStr.length();
 
@@ -150,7 +150,7 @@ public class ConnectionProcessor implements Runnable {
 
         if (requestHeaderCustomValues_ != null) {
             //if there are custom header values, add them
-            L.v("[ConnectionProcessor] Adding [" + requestHeaderCustomValues_.size() + "] custom header fields");
+            L.v("[Connection Processor] Adding [" + requestHeaderCustomValues_.size() + "] custom header fields");
             for (Map.Entry<String, String> entry : requestHeaderCustomValues_.entrySet()) {
                 String key = entry.getKey();
                 String value = entry.getValue();
@@ -160,7 +160,7 @@ public class ConnectionProcessor implements Runnable {
             }
         }
 
-        L.v("[ConnectionProcessor] Has picturePath [" + hasPicturePath + "]");
+        L.v("[Connection Processor] Has picturePath [" + hasPicturePath + "]");
 
         if (hasPicturePath) {
             String boundary = Long.toHexString(System.currentTimeMillis());// Just generate some unique random value as the boundary
@@ -204,7 +204,7 @@ public class ConnectionProcessor implements Runnable {
                 writer.close();
                 os.close();
             } else {
-                L.v("[ConnectionProcessor] Using HTTP GET");
+                L.v("[Connection Processor] Using HTTP GET");
                 conn.setDoOutput(false);
             }
         }
@@ -232,7 +232,7 @@ public class ConnectionProcessor implements Runnable {
                 approximateDateSize += key.getBytes("US-ASCII").length + value.getBytes("US-ASCII").length + 2L;
             }
         } catch (Exception e) {
-            L.e("[ConnectionProcessor] urlConnectionForServerRequest, exception while calculating header field size: " + e);
+            L.e("[Connection Processor] urlConnectionForServerRequest, exception while calculating header field size: " + e);
         }
 
         long headerFieldSizeTime = UtilsTime.getNanoTime() - pccTsStartHeaderFieldSize;
@@ -241,7 +241,7 @@ public class ConnectionProcessor implements Runnable {
             pcc.TrackCounterTimeNs("ConnectionProcessorUrlConnectionForServerRequest_03_HeaderFieldSize", headerFieldSizeTime);
         }
 
-        L.v("[ConnectionProcessor] Using HTTP POST: [" + usingHttpPost + "] forced:[" + requestInfoProvider_.isHttpPostForced()
+        L.v("[Connection Processor] Using HTTP POST: [" + usingHttpPost + "] forced:[" + requestInfoProvider_.isHttpPostForced()
             + "] length:[" + (requestData.length() >= 2048) + "] crash:[" + requestData.contains("&crash=") + "] | Approx data size: [" + approximateDateSize + " B]");
         return conn;
     }
@@ -293,7 +293,7 @@ public class ConnectionProcessor implements Runnable {
                 }
             } catch (IOException ex) {
                 for (StackTraceElement e : ex.getStackTrace()) {
-                    L.e("[ConnectionProcessor] addMultipart, error: " + e);
+                    L.e("[Connection Processor] addMultipart, error: " + e);
                 }
             }
         }
@@ -319,7 +319,7 @@ public class ConnectionProcessor implements Runnable {
             long pccTsStartHandlingResponse;
 
             if (!configProvider_.getNetworkingEnabled()) {
-                L.w("[ConnectionProcessor] run, Networking config is disabled, request queue skipped");
+                L.w("[Connection Processor] run, Networking config is disabled, request queue skipped");
                 break;
             }
 
@@ -328,7 +328,7 @@ public class ConnectionProcessor implements Runnable {
             final String[] storedRequests = storageProvider_.getRequests();
             int storedRequestCount = storedRequests == null ? 0 : storedRequests.length;
 
-            String msg = "[ConnectionProcessor] Starting to run, there are [" + storedRequestCount + "] requests stored";
+            String msg = "[Connection Processor] Starting to run, there are [" + storedRequestCount + "] requests stored";
             if (storedRequestCount == 0) {
                 L.v(msg);
             } else {
@@ -336,17 +336,17 @@ public class ConnectionProcessor implements Runnable {
             }
 
             if (storedRequests == null || storedRequestCount == 0) {
-                L.i("[ConnectionProcessor] No requests in the queue, request queue skipped");
+                L.i("[Connection Processor] No requests in the queue, request queue skipped");
                 // currently no data to send, we are done for now
                 break;
             }
 
-            L.i("[ConnectionProcessor] Starting to run, there are [" + storedRequestCount + "] requests stored");
+            L.i("[Connection Processor] Starting to run, there are [" + storedRequestCount + "] requests stored");
 
             if (deviceIdProvider_.getDeviceId() == null) {
                 // When device ID is supplied by OpenUDID or by Google Advertising ID.
                 // In some cases it might take time for them to initialize. So, just wait for it.
-                L.i("[ConnectionProcessor] No Device ID available yet, skipping request " + storedRequests[0]);
+                L.i("[Connection Processor] No Device ID available yet, skipping request " + storedRequests[0]);
                 break;
             }
 
@@ -364,8 +364,8 @@ public class ConnectionProcessor implements Runnable {
                 pccTsStartOldRCheck = UtilsTime.getNanoTime();
             }
 
-            L.i("[ConnectionProcessor] Checking if the request is older than:[" + requestInfoProvider_.getRequestDropAgeHours() + "] hours");
-            boolean isRequestOld = Utils.isRequestTooOld(requestData, requestInfoProvider_.getRequestDropAgeHours(), "[ConnectionProcessor]", L);
+            L.i("[Connection Processor] Checking if the request is older than:[" + requestInfoProvider_.getRequestDropAgeHours() + "] hours");
+            boolean isRequestOld = Utils.isRequestTooOld(requestData, requestInfoProvider_.getRequestDropAgeHours(), "[Connection Processor]", L);
 
             if (pcc != null) {
                 pcc.TrackCounterTimeNs("ConnectionProcessorRun_02_NetworkOldReq", UtilsTime.getNanoTime() - pccTsStartOldRCheck);
@@ -386,7 +386,7 @@ public class ConnectionProcessor implements Runnable {
                 //the internally set id is the temporary one
 
                 //abort and wait for exiting temporary mode
-                L.i("[ConnectionProcessor] Temporary ID detected, stalling requests. Id override:[" + containsTemporaryIdOverride + "], tmp id tag:[" + containsTemporaryId + "], temp ID set:[" + deviceIdProvider_.isTemporaryIdEnabled() + "]");
+                L.i("[Connection Processor] Temporary ID detected, stalling requests. Id override:[" + containsTemporaryIdOverride + "], tmp id tag:[" + containsTemporaryId + "], temp ID set:[" + deviceIdProvider_.isTemporaryIdEnabled() + "]");
                 break;
             }
             if (pcc != null) {
@@ -409,7 +409,7 @@ public class ConnectionProcessor implements Runnable {
                 if (!extractionResult[1].isEmpty()) {
                     customEndpoint = extractionResult[1];
                 }
-                L.v("[ConnectionProcessor] Custom end point detected for the request:[" + customEndpoint + "]");
+                L.v("[Connection Processor] Custom end point detected for the request:[" + customEndpoint + "]");
             }
 
             if (pcc != null) {
@@ -450,7 +450,7 @@ public class ConnectionProcessor implements Runnable {
 
                         deviceIdChange = false;
 
-                        L.d("[ConnectionProcessor] Provided device_id is the same as the previous one used, nothing will be merged");
+                        L.d("[Connection Processor] Provided device_id is the same as the previous one used, nothing will be merged");
                     } else {
                         //new device_id provided, make sure it will be merged
                         requestData = requestData + "&old_device_id=" + UtilsNetworking.urlEncodeString(deviceIdProvider_.getDeviceId());
@@ -525,7 +525,7 @@ public class ConnectionProcessor implements Runnable {
                     }
 
                     long readingStreamTime = UtilsTime.getNanoTime() - pccTsReadingStream;
-                    L.d("[ConnectionProcessor] code:[" + responseCode + "], response:[" + responseString + "], response size:[" + responseString.length() + " B], request: " + requestData + ", url: " + serverURL_ + ", Reading stream took:[" + readingStreamTime / 1000000.0d + "] ms");
+                    L.d("[Connection Processor] code:[" + responseCode + "], response:[" + responseString + "], response size:[" + responseString.length() + " B], request: " + requestData + ", url: " + serverURL_ + ", Reading stream took:[" + readingStreamTime / 1000000.0d + "] ms");
 
                     if (pcc != null) {
                         pcc.TrackCounterTimeNs("ConnectionProcessorRun_13_ReadingStream", readingStreamTime);
@@ -536,7 +536,7 @@ public class ConnectionProcessor implements Runnable {
                     if (responseCode >= 200 && responseCode < 300) {
 
                         if (responseString.isEmpty()) {
-                            L.v("[ConnectionProcessor] Response was empty, will retry");
+                            L.v("[Connection Processor] Response was empty, will retry");
                             rRes = RequestResult.RETRY;
                         } else {
                             JSONObject jsonObject;
@@ -545,37 +545,37 @@ public class ConnectionProcessor implements Runnable {
                             } catch (JSONException ex) {
                                 //failed to parse, so not a valid json
                                 jsonObject = null;
-                                L.e("[ConnectionProcessor] Failed to parse response [" + responseString + "].");
+                                L.e("[Connection Processor] Failed to parse response [" + responseString + "].");
                             }
 
                             if (jsonObject == null) {
                                 //received unparseable response, retrying
-                                L.v("[ConnectionProcessor] Response was a unknown, will retry");
+                                L.v("[Connection Processor] Response was a unknown, will retry");
                                 rRes = RequestResult.RETRY;
                             } else {
                                 if (jsonObject.has("result")) {
                                     //contains result entry
-                                    L.v("[ConnectionProcessor] Response was a success");
+                                    L.v("[Connection Processor] Response was a success");
                                     rRes = RequestResult.OK;
                                 } else {
-                                    L.v("[ConnectionProcessor] Response does not contain 'result', will retry");
+                                    L.v("[Connection Processor] Response does not contain 'result', will retry");
                                     rRes = RequestResult.RETRY;
                                 }
                             }
                         }
                     } else if (responseCode >= 300 && responseCode < 400) {
                         //assume redirect
-                        L.d("[ConnectionProcessor] Encountered redirect, will retry");
+                        L.d("[Connection Processor] Encountered redirect, will retry");
                         rRes = RequestResult.RETRY;
                     } else if (responseCode == 400 || responseCode == 404) {
-                        L.w("[ConnectionProcessor] Bad request, will still retry");
+                        L.w("[Connection Processor] Bad request, will still retry");
                         rRes = RequestResult.RETRY;
                     } else if (responseCode > 400) {
                         //server down, try again later
-                        L.d("[ConnectionProcessor] Server is down, will retry");
+                        L.d("[Connection Processor] Server is down, will retry");
                         rRes = RequestResult.RETRY;
                     } else {
-                        L.d("[ConnectionProcessor] Bad response code, will retry");
+                        L.d("[Connection Processor] Bad response code, will retry");
                         rRes = RequestResult.RETRY;
                     }
 
@@ -590,12 +590,12 @@ public class ConnectionProcessor implements Runnable {
                             if (newId != null && !newId.isEmpty()) {
                                 deviceIdProvider_.getDeviceIdInstance().changeToCustomId(newId);//todo needs to be refactored
                             } else {
-                                L.e("[ConnectionProcessor] Failed to change device ID with merging because the new ID was empty or null. [" + newId + "]");
+                                L.e("[Connection Processor] Failed to change device ID with merging because the new ID was empty or null. [" + newId + "]");
                             }
                         }
 
                         if (deviceIdChange || deviceIdOverride) {
-                            L.v("[ConnectionProcessor] Device ID changed, change:[" + deviceIdChange + "] | override:[" + deviceIdOverride + "]");
+                            L.v("[Connection Processor] Device ID changed, change:[" + deviceIdChange + "] | override:[" + deviceIdOverride + "]");
                             Countly.sharedInstance().notifyDeviceIdChange();//todo needs to be removed at some point
                         }
                     } else {
@@ -611,7 +611,7 @@ public class ConnectionProcessor implements Runnable {
                         break;
                     }
                 } catch (Exception e) {
-                    L.d("[ConnectionProcessor] Got exception while trying to submit request data: [" + requestData + "] [" + e + "]");
+                    L.d("[Connection Processor] Got exception while trying to submit request data: [" + requestData + "] [" + e + "]");
                     // if exception occurred, stop processing, let next tick take care of retrying
                     if (pcc != null) {
                         pcc.TrackCounterTimeNs("ConnectionProcessorRun_11_NetworkWholeQueueException", UtilsTime.getNanoTime() - pccTsStartWholeQueue);
@@ -638,9 +638,9 @@ public class ConnectionProcessor implements Runnable {
             } else {
                 //device is identified as a app crawler and nothing is sent to the server
                 if (isRequestOld) {
-                    L.i("[ConnectionProcessor] request is too old, removing request " + originalRequest);
+                    L.i("[Connection Processor] request is too old, removing request " + originalRequest);
                 } else {
-                    L.i("[ConnectionProcessor] Device identified as an app crawler, removing request " + originalRequest);
+                    L.i("[Connection Processor] Device identified as an app crawler, removing request " + originalRequest);
                 }
 
                 //remove stored data

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
@@ -293,7 +293,7 @@ public class ConnectionProcessor implements Runnable {
                 }
             } catch (IOException ex) {
                 for (StackTraceElement e : ex.getStackTrace()) {
-                    L.e("[Connection Processor] addMultipart, error: " + e);
+                    L.e("[ConnectionProcessor] addMultipart, error: " + e);
                 }
             }
         }

--- a/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ConnectionProcessor.java
@@ -328,7 +328,14 @@ public class ConnectionProcessor implements Runnable {
             final String[] storedRequests = storageProvider_.getRequests();
             int storedRequestCount = storedRequests == null ? 0 : storedRequests.length;
 
+            String msg = "[ConnectionProcessor] Starting to run, there are [" + storedRequestCount + "] requests stored";
             if (storedRequestCount == 0) {
+                L.v(msg);
+            } else {
+                L.i(msg);
+            }
+
+            if (storedRequests == null || storedRequestCount == 0) {
                 L.i("[ConnectionProcessor] No requests in the queue, request queue skipped");
                 // currently no data to send, we are done for now
                 break;


### PR DESCRIPTION
Converted "Connection Processor" tags to "ConnectionProcessor"

Added 4 new PCC times for 
- calculation reading stream of the request
- Opening URL connection
- Configuring URL connection
- Getting headers for length calculation

Made some refactoring for unnecessary L.logEnabled() call on line 308

Time logs have "TIMING" tag with them to differentiate easier while debugging
Added time logs for:
- Opening URL connection
- Configuring URL connection
- Getting headers for length calculation
- Handling response
- Setup server request
- Whole queue loop