### PR TITLE
New internal limits utils func to be used with value size

### DIFF
--- a/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
@@ -406,6 +406,24 @@ public class UtilsInternalLimitsTests {
     }
 
     @Test
+    public void applySdkInternalLimitsToSegmentation_clipSegmentationValues() {
+        Map<String, Object> segmentation = new ConcurrentHashMap<>();
+        segmentation.put("test_test", "value1");
+        segmentation.put("test", new ArrayList<>());
+        segmentation.put("map_too", TestUtils.map("a", 1));
+
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(20)
+            .setMaxValueSize(1)
+            .setMaxSegmentationValues(10);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+
+        Assert.assertEquals(1, segmentation.size());
+        Assert.assertEquals("v", segmentation.get("test_test"));
+    }
+
+    @Test
     public void applySdkInternalLimitsToSegmentation_null() {
         Map<String, Object> segmentation = null;
         ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()

--- a/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
@@ -486,4 +486,21 @@ public class UtilsInternalLimitsTests {
         Assert.assertEquals("ma", breadcrumbs.get(1));
         Assert.assertEquals("ji", breadcrumbs.get(2));
     }
+
+    /**
+     * "applySdkInternalLimitsToSegmentation" with key length limit and value size of 2
+     * Validate that clipped values clashes with same keys and overridden each other
+     * "bb" key should have value from the second of the last value which is "dd"
+     */
+    @Test
+    public void applySdkInternalLimitsToSegmentation_clashingKeys() {
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits();
+        limitsConfig.setMaxValueSize(2).setMaxKeyLength(2).setMaxSegmentationValues(10);
+
+        Map<String, Object> segmentation = TestUtils.map("a", 1, "bbb", "bbb", "bbc", "ccc", "bbd", "ddd", "bbe", "eee");
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+        Assert.assertEquals(2, segmentation.size());
+        Assert.assertEquals(1, segmentation.get("a"));
+        Assert.assertEquals("dd", segmentation.get("bb"));
+    }
 }

--- a/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
@@ -1,6 +1,7 @@
 package ly.count.android.sdk;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -382,9 +383,26 @@ public class UtilsInternalLimitsTests {
         UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
 
         Assert.assertEquals(3, segmentation.size());
-        Assert.assertEquals("12", segmentation.get("abcde"));
+        Assert.assertEquals(456789, segmentation.get("hobbi"));
         Assert.assertEquals("va", segmentation.get("test_"));
-        Assert.assertEquals(TestUtils.map("a", 1), segmentation.get("map_t"));
+        Assert.assertEquals(45.678f, segmentation.get("map_t"));
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation_removeUnsupportedDataTypes() {
+        Map<String, Object> segmentation = new ConcurrentHashMap<>();
+        segmentation.put("test_test", new int[] { 1, 2, 3 });
+        segmentation.put("test", new ArrayList<>());
+        segmentation.put("map_too", TestUtils.map("a", 1));
+
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(10)
+            .setMaxValueSize(10)
+            .setMaxSegmentationValues(10);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+
+        Assert.assertEquals(0, segmentation.size());
     }
 
     @Test

--- a/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
@@ -1,309 +1,489 @@
 package ly.count.android.sdk;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
-public class UtilsInternalLimits {
+import static org.mockito.Mockito.mock;
 
-    private UtilsInternalLimits() {
+@RunWith(AndroidJUnit4.class)
+public class UtilsInternalLimitsTests {
+
+    /**
+     * "truncateKeyLength"
+     * Test that the key (test) is truncated to the limit (2)
+     * Expected result: "te"
+     */
+    @Test
+    public void truncateKeyLength() {
+        String key = "test";
+        int limit = 2;
+
+        String truncatedKey = UtilsInternalLimits.truncateKeyLength(key, limit, new ModuleLog(), "tag");
+        Assert.assertEquals("te", truncatedKey);
     }
 
     /**
-     * This function is intended to be used to truncate the length of a key to a certain limit.
-     * It is used to ensure that the key length does not exceed the limit set by the SDK.
-     * If the key length exceeds the limit, the key is truncated to the limit.
-     * If the key length is less than or equal to the limit, the key is returned as is.
-     * Used truncate method is substring. from 0 to limit.
-     * <pre>
-     * Intended to be used for those:
-     * - event names
-     * - view names
-     * - custom trace key name (APM)
-     * - custom metric key (APM)
-     * - segmentation key (for all features)
-     * - custom user property
-     * - custom user property keys that are used for property modifiers (mul, push, pull, set, increment, etc)
-     * </pre>
-     *
-     * @param key to truncate
-     * @param limit to truncate to
-     * @param L logger
-     * @return truncated key
+     * "truncateKeyLength"
+     * Test that the key (null) is not truncated
+     * Expected result: null
      */
-    protected static String truncateKeyLength(@Nullable String key, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
-        return truncateString(key, limit, L, tag + ": [UtilsSdkInternalLimits] truncateKeyLength");
+    @Test
+    public void truncateKeyLength_null() {
+        String key = null;
+        int limit = 4;
+        ModuleLog spyLog = Mockito.spy(new ModuleLog());
+
+        String truncatedKey = UtilsInternalLimits.truncateKeyLength(key, limit, spyLog, "tag");
+        Assert.assertNull(truncatedKey);
+        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateKeyLength, value is null, returning");
     }
 
     /**
-     * Limits the size of all values in our key-value pairs.
-     * "Value" fields include:
-     * <pre>
-     * - segmentation value in case of strings (for all features)
-     * - custom user property string value
-     * - user profile named key (username, email, etc) string values. Except the "picture" field, which has a limit of 4096 chars
-     * - custom user property modifier string values. For example, for modifiers like "push," "pull," "setOnce", etc.
-     * - breadcrumb text
-     * - manual feedback widget reporting fields (reported as an event)
-     * - rating widget response (reported as an event)
-     * </pre>
-     *
-     * @param value to truncate
-     * @param limit to truncate to
-     * @param L logger
-     * @return truncated key
+     * "truncateKeyLength"
+     * Test that the key (empty) is not truncated
+     * Expected result: empty string
+     * Validate empty check log is called
      */
-    protected static String truncateValueSize(@Nullable String value, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
-        return truncateString(value, limit, L, tag + ": [UtilsSdkInternalLimits] truncateValueSize");
-    }
+    @Test
+    public void truncateKeyLength_empty() {
+        String key = "";
+        int limit = 4;
+        ModuleLog spyLog = Mockito.spy(new ModuleLog());
 
-    private static String truncateString(@Nullable String value, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
-        if (value == null) {
-            L.w(tag + ", value is null, returning");
-            return value;
-        }
-
-        if (value.isEmpty()) {
-            L.w(tag + ", value is empty, returning");
-            return value;
-        }
-
-        if (value.length() > limit) {
-            String truncatedValue = value.substring(0, limit);
-            L.w(tag + ", Value length exceeds limit of " + limit + " characters. Truncating value to " + limit + " characters. Truncated to " + truncatedValue);
-            return truncatedValue;
-        }
-        return value;
+        String truncatedKey = UtilsInternalLimits.truncateKeyLength(key, limit, spyLog, "tag");
+        Assert.assertEquals("", truncatedKey);
+        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateKeyLength, value is empty, returning");
     }
 
     /**
-     * This function is intended to be used with truncating map keys
-     * Uses truncateKeyLength to truncate keys in a map to a certain limit.
-     *
-     * @param map to truncate keys
-     * @param limit to truncate keys to
-     * @param L logger
-     * @param <T> type of map value
+     * "truncateKeyLength"
+     * Limit is 4
+     * Test that the first key (test_test) is truncated
+     * Expected result: "test"
+     * Test that the second key (test) is not truncated
+     * Expected result: "test"
      */
-    protected static <T> void truncateSegmentationKeys(@Nullable Map<String, T> map, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
-        if (map == null) {
-            L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, map is null, returning");
-            return;
-        }
+    @Test
+    public void truncateKeyLength_multiple() {
+        String firstKey = "test_test";
+        String secondKey = "test";
+        int limit = 4;
 
-        if (map.isEmpty()) {
-            L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, map is empty, returning");
-            return;
-        }
+        String firstTruncatedKey = UtilsInternalLimits.truncateKeyLength(firstKey, limit, new ModuleLog(), "tag");
+        String secondTruncatedKey = UtilsInternalLimits.truncateKeyLength(secondKey, limit, new ModuleLog(), "tag");
 
-        L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, map:[" + map + "]");
-        // Replacing keys in a map is not safe, so we create a new map and put them after
-        Map<String, T> gonnaReplace = new ConcurrentHashMap<>();
-        List<String> gonnaRemove = new ArrayList<>();
-
-        for (Map.Entry<String, T> entry : map.entrySet()) {
-            String truncatedKey = truncateKeyLength(entry.getKey(), limit, L, tag);
-            if (!truncatedKey.equals(entry.getKey())) {
-                // add truncated key
-                gonnaReplace.put(truncatedKey, entry.getValue());
-                // remove not truncated key
-                gonnaRemove.add(entry.getKey());
-            }
-        }
-
-        for (String key : gonnaRemove) {
-            map.remove(key);
-        }
-
-        map.putAll(gonnaReplace);
-    }
-
-    protected static void truncateSegmentationKeysValues(@NonNull Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
-        L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, segmentation:[" + segmentation + "]");
-        // Replacing keys in a map is not safe, so we create a new map and put them after
-        Iterator<Map.Entry<String, Object>> iterator = segmentation.entrySet().iterator();
-        Map<String, Object> gonnaReplace = new ConcurrentHashMap<>();
-
-        while (iterator.hasNext()) {
-            Map.Entry<String, Object> entry = iterator.next();
-            String truncatedKey = truncateKeyLength(entry.getKey(), limitsConfig.maxKeyLength, L, tag);
-            Object value = entry.getValue();
-
-            if (!isSupportedDataType(value)) {
-                iterator.remove();
-                continue;
-            }
-
-            if (value instanceof String) {
-                value = truncateValueSize((String) value, limitsConfig.maxValueSize, L, tag);
-            }
-            if (!truncatedKey.equals(entry.getKey())) {
-                iterator.remove(); // Removes the current entry from the original map
-                gonnaReplace.put(truncatedKey, value); // Store the new entry to be replaced later
-            } else if (value instanceof String && !value.equals(entry.getValue())) {
-                segmentation.put(truncatedKey, value); // Update value directly
-            }
-        }
-
-        segmentation.putAll(gonnaReplace);
+        Assert.assertEquals("test", firstTruncatedKey);
+        Assert.assertEquals(secondKey, secondTruncatedKey);
     }
 
     /**
-     * Removes unsupported data types and applies following internal limits to the provided segmentation map:
-     * - max key length
-     * - max value size
-     * - max number of keys
-     *
-     * @param segmentation Map<String, Object> @Nullable - segmentation map to apply limits to
-     * @param limitsConfig ConfigSdkInternalLimits @NonNull - limits configuration
-     * @param L ModuleLog @NonNull - logger
-     * @param tag String @NonNull - tag to use in logs
+     * "truncateSegmentationKeys"
+     * Limit is 5
+     * Test that the first key (test_test) is truncated
+     * Expected result: "test_", Expected value: "value1"
+     * Test that the second key (test) is not truncated
+     * Expected result: "test", Expected value: "value2"
      */
-    protected static void applySdkInternalLimitsToSegmentation(@Nullable Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
-        assert limitsConfig != null;
-        assert L != null;
-        assert tag != null;
+    @Test
+    public void truncateSegmentationKeys() {
+        int limit = 5;
+        Map<String, String> map = new ConcurrentHashMap<>();
+        map.put("test_test", "value1");
+        map.put("test", "value2");
 
-        if (segmentation == null) {
-            L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is null, returning");
-            return;
-        }
+        UtilsInternalLimits.truncateSegmentationKeys(map, limit, new ModuleLog(), "tag");
 
-        if (segmentation.isEmpty()) {
-            L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is empty, returning");
-            return;
-        }
-
-        truncateSegmentationKeysValues(segmentation, limitsConfig, L, tag);
-        truncateSegmentationValues(segmentation, limitsConfig.maxSegmentationValues, tag, L);
+        Assert.assertEquals("value1", map.get("test_"));
+        Assert.assertEquals("value2", map.get("test"));
     }
 
     /**
-     * Applies the following internal limits to the provided breadcrumbs:
-     * - max value size
-     * - max number of breadcrumbs
-     *
-     * @param breadcrumbs List<String> @NonNull - breadcrumbs to apply limits to
-     * @param limitsConfig ConfigSdkInternalLimits @NonNull - limits configuration
-     * @param L ModuleLog @NonNull - logger
-     * @param tag String @NonNull - tag to use in logs
+     * "truncateSegmentationKeys" with null map
+     * Validate null check log is called
      */
-    static void applyInternalLimitsToBreadcrumbs(@NonNull List<String> breadcrumbs, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
-        assert breadcrumbs != null;
-        assert limitsConfig != null;
-        assert L != null;
-        assert tag != null;
+    @Test
+    public void truncateSegmentationKeys_null() {
+        int limit = 5;
+        Map<String, String> map = null;
 
-        if (breadcrumbs.isEmpty()) {
-            L.w(tag + ": [UtilsSdkInternalLimits] applyInternalLimitsToBreadcrumbs, breadcrumbs is empty, returning");
-            return;
-        }
-
-        Iterator<String> iterator = breadcrumbs.iterator();
-        while (iterator.hasNext()) {
-            if (breadcrumbs.size() > limitsConfig.maxBreadcrumbCount) {
-                String breadcrumb = iterator.next();
-                L.w(tag + ": [UtilsSdkInternalLimits] applyInternalLimitsToBreadcrumbs, breadcrumb:[" + breadcrumb + "]");
-                iterator.remove();
-            } else {
-                break;
-            }
-        }
-
-        for (int i = 0; i < breadcrumbs.size(); i++) {
-            String breadcrumb = breadcrumbs.get(i);
-            String truncatedBreadcrumb = truncateValueSize(breadcrumb, limitsConfig.maxValueSize, L, tag);
-            if (!truncatedBreadcrumb.equals(breadcrumb)) {
-                breadcrumbs.set(i, truncatedBreadcrumb);
-            }
-        }
+        UtilsInternalLimits.truncateSegmentationKeys(map, limit, new ModuleLog(), "tag");
+        Assert.assertNull(map);
     }
 
     /**
-     * Checks and transforms the provided Object if it does not
-     * comply with the key count limit.
-     *
-     * @param maxCount Int @NonNull - max number of keys allowed
-     * @param L ModuleLog @NonNull - Logger function
-     * @param messagePrefix String @NonNull - name of the module this function was called
-     * @param segmentation Map<String, Object> @Nullable- segmentation that will be checked
+     * "truncateSegmentationKeys" with empty map
+     * Validate map is empty
      */
-    static void truncateSegmentationValues(@Nullable final Map<String, Object> segmentation, final int maxCount, @NonNull final String messagePrefix, final @NonNull ModuleLog L) {
-        if (segmentation == null) {
-            return;
-        }
+    @Test
+    public void truncateSegmentationKeys_empty() {
+        int limit = 5;
+        Map<String, String> map = new ConcurrentHashMap<>();
 
-        Iterator<Map.Entry<String, Object>> iterator = segmentation.entrySet().iterator();
-        while (iterator.hasNext()) {
-            if (segmentation.size() > maxCount) {
-                Map.Entry<String, Object> value = iterator.next();
-                String key = value.getKey();
-                L.w(messagePrefix + ", Value exceeded the maximum segmentation count key:[" + key + "]");
-                iterator.remove();
-            } else {
-                break;
-            }
-        }
+        UtilsInternalLimits.truncateSegmentationKeys(map, limit, new ModuleLog(), "tag");
+        Assert.assertEquals(0, map.size());
     }
 
     /**
-     * Used to remove reserved keys from segmentation map
-     *
-     * @param segmentation
-     * @param reservedKeys
-     * @param messagePrefix
-     * @param L
+     * "truncateSegmentationKeys" with same base keys
+     * Limit is 4
+     * Map has keys "test1", "test2", "test3", "test4", "test5"
+     * Resulting map will have only one key, and it is "test"
+     * All values are removed and only one value is kept which is the last one what map.entrySet() returns
      */
-    static void removeReservedKeysFromSegmentation(@Nullable Map<String, Object> segmentation, @NonNull String[] reservedKeys, @NonNull String messagePrefix, @NonNull ModuleLog L) {
-        if (segmentation == null) {
-            return;
-        }
+    @Test
+    public void truncateSegmentationKeys_inconsistentKeys() {
+        int limit = 4;
+        Map<String, String> map = new ConcurrentHashMap<>();
+        map.put("test1", TestUtils.eKeys[0]);
+        map.put("test2", TestUtils.eKeys[1]);
+        map.put("test3", TestUtils.eKeys[2]);
+        map.put("test4", TestUtils.eKeys[3]);
+        map.put("test5", TestUtils.eKeys[4]);
+        ModuleLog spyLog = Mockito.spy(new ModuleLog());
 
-        for (String rKey : reservedKeys) {
-            if (segmentation.containsKey(rKey)) {
-                L.w(messagePrefix + " provided segmentation contains protected key [" + rKey + "]");
-                segmentation.remove(rKey);
-            }
-        }
+        UtilsInternalLimits.truncateSegmentationKeys(map, limit, spyLog, "tag");
+        Assert.assertEquals(1, map.size());
+        Assert.assertFalse(Objects.requireNonNull(map.get("test")).isEmpty());
     }
 
     /**
-     * Removes unsupported data types
-     *
-     * @param data
-     * @return returns true if any entry had been removed
+     * Make sure that nothing bad happens when providing null segmentation
      */
-    static boolean removeUnsupportedDataTypes(Map<String, Object> data) {
-        if (data == null) {
-            return false;
-        }
-
-        boolean removed = false;
-
-        for (Iterator<Map.Entry<String, Object>> it = data.entrySet().iterator(); it.hasNext(); ) {
-            Map.Entry<String, Object> entry = it.next();
-            String key = entry.getKey();
-            Object value = entry.getValue();
-
-            if (key == null || key.isEmpty() || !(isSupportedDataType(value))) {
-                //found unsupported data type or null key or value, removing
-                it.remove();
-                removed = true;
-            }
-        }
-
-        if (removed) {
-            Countly.sharedInstance().L.w("[Utils] Unsupported data types were removed from provided segmentation");
-        }
-
-        return removed;
+    @Test
+    public void truncateSegmentationValues_null() {
+        UtilsInternalLimits.truncateSegmentationValues(null, 10, "someTag", mock(ModuleLog.class));
+        Assert.assertTrue(true);
     }
 
-    static boolean isSupportedDataType(Object value) {
-        return value instanceof String || value instanceof Integer || value instanceof Double || value instanceof Boolean || value instanceof Float;
+    /**
+     * Make sure that nothing bad happens when providing empty segmentation
+     */
+    @Test
+    public void truncateSegmentationValues_empty() {
+        Map<String, Object> values = new HashMap<>();
+        UtilsInternalLimits.truncateSegmentationValues(values, 10, "someTag", mock(ModuleLog.class));
+        Assert.assertTrue(true);
+    }
+
+    /**
+     * Make sure that nothing bad happens when providing segmentation with values under limit
+     */
+    @Test
+    public void truncateSegmentationValues_underLimit() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("a1", "1");
+        values.put("a2", "2");
+        values.put("a3", "3");
+        values.put("a4", "4");
+        UtilsInternalLimits.truncateSegmentationValues(values, 6, "someTag", mock(ModuleLog.class));
+
+        Assert.assertEquals(4, values.size());
+        Assert.assertEquals("1", values.get("a1"));
+        Assert.assertEquals("2", values.get("a2"));
+        Assert.assertEquals("3", values.get("a3"));
+        Assert.assertEquals("4", values.get("a4"));
+    }
+
+    /**
+     * Make sure that values are truncated when they are more then the limit
+     */
+    @Test
+    public void truncateSegmentationValues_aboveLimit() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("a1", "1");
+        values.put("a2", "2");
+        values.put("a3", "3");
+        values.put("a4", "4");
+        UtilsInternalLimits.truncateSegmentationValues(values, 2, "someTag", mock(ModuleLog.class));
+
+        Assert.assertEquals(2, values.size());
+        //after inspecting what is returned in the debugger, it should have the values of "a2" and "a4"
+        //Assert.assertEquals("2", values.get("a2"));
+        //Assert.assertEquals("4", values.get("a4"));
+    }
+
+    @Test
+    public void removeReservedKeysFromSegmentation() {
+        Map<String, Object> values = new HashMap<>();
+
+        UtilsInternalLimits.removeReservedKeysFromSegmentation(values, new String[] {}, "", mock(ModuleLog.class));
+        Assert.assertEquals(0, values.size());
+
+        UtilsInternalLimits.removeReservedKeysFromSegmentation(values, new String[] { "a", "", null }, "", mock(ModuleLog.class));
+        Assert.assertEquals(0, values.size());
+
+        values.put("b", 1);
+        Assert.assertEquals(1, values.size());
+        UtilsInternalLimits.removeReservedKeysFromSegmentation(values, new String[] { "a", "a1", "", null }, "", mock(ModuleLog.class));
+        Assert.assertEquals(1, values.size());
+        Assert.assertTrue(values.containsKey("b"));
+
+        values.put("a", 2);
+        Assert.assertEquals(2, values.size());
+        UtilsInternalLimits.removeReservedKeysFromSegmentation(values, new String[] { "a", "a1", "", null }, "", mock(ModuleLog.class));
+        Assert.assertEquals(1, values.size());
+        Assert.assertTrue(values.containsKey("b"));
+
+        values.put("a", 2);
+        values.put("c", 3);
+        Assert.assertEquals(3, values.size());
+        UtilsInternalLimits.removeReservedKeysFromSegmentation(values, new String[] { "a", "a1", "", null }, "", mock(ModuleLog.class));
+        Assert.assertEquals(2, values.size());
+        Assert.assertTrue(values.containsKey("b"));
+        Assert.assertTrue(values.containsKey("c"));
+    }
+
+    @Test
+    public void removeUnsupportedDataTypesNull() {
+        Assert.assertFalse(UtilsInternalLimits.removeUnsupportedDataTypes(null));
+    }
+
+    @Test
+    public void removeUnsupportedDataTypes() {
+        Map<String, Object> segm = new HashMap<>();
+
+        segm.put("aa", "dd");
+        segm.put("aa1", "dda");
+        segm.put("1", 1234);
+        segm.put("2", 1234.55d);
+        segm.put("3", true);
+        segm.put("4", 45.4f);
+        segm.put("41", new Object());
+        segm.put("42", new int[] { 1, 2 });
+
+        Assert.assertTrue(UtilsInternalLimits.removeUnsupportedDataTypes(segm));
+
+        Assert.assertTrue(segm.containsKey("aa"));
+        Assert.assertTrue(segm.containsKey("aa1"));
+        Assert.assertTrue(segm.containsKey("1"));
+        Assert.assertTrue(segm.containsKey("2"));
+        Assert.assertTrue(segm.containsKey("3"));
+        Assert.assertTrue(segm.containsKey("4"));
+        Assert.assertFalse(segm.containsKey("41"));
+        Assert.assertFalse(segm.containsKey("42"));
+    }
+
+    @Test
+    public void removeUnsupportedDataTypes2() {
+        Map<String, Object> segm = new HashMap<>();
+
+        segm.put("", "dd");
+        segm.put(null, "dda");
+        segm.put("aa", null);
+
+        Assert.assertEquals(3, segm.size());
+
+        Assert.assertTrue(UtilsInternalLimits.removeUnsupportedDataTypes(segm));
+
+        Assert.assertEquals(0, segm.size());
+
+        segm.put(null, null);
+        segm.put("1", "dd");
+        segm.put("2", 123);
+        segm.put("", null);
+        segm.put("3", 345.33d);
+        segm.put("4", false);
+        segm.put("aa1", new String[] { "ff", "33" });
+
+        Assert.assertEquals(7, segm.size());
+
+        Assert.assertTrue(UtilsInternalLimits.removeUnsupportedDataTypes(segm));
+
+        Assert.assertEquals(4, segm.size());
+        Assert.assertTrue(segm.containsKey("1"));
+        Assert.assertTrue(segm.containsKey("2"));
+        Assert.assertTrue(segm.containsKey("3"));
+        Assert.assertTrue(segm.containsKey("4"));
+        Assert.assertEquals("dd", segm.get("1"));
+        Assert.assertEquals(123, segm.get("2"));
+        Assert.assertEquals(345.33d, segm.get("3"));
+        Assert.assertEquals(false, segm.get("4"));
+    }
+
+    @Test
+    public void isSupportedDataType() {
+        Assert.assertTrue(UtilsInternalLimits.isSupportedDataType("string"));
+        Assert.assertTrue(UtilsInternalLimits.isSupportedDataType(123));
+        Assert.assertTrue(UtilsInternalLimits.isSupportedDataType(123.33d));
+        Assert.assertTrue(UtilsInternalLimits.isSupportedDataType(123.33f));
+        Assert.assertTrue(UtilsInternalLimits.isSupportedDataType(true));
+        Assert.assertTrue(UtilsInternalLimits.isSupportedDataType(false));
+        Assert.assertFalse(UtilsInternalLimits.isSupportedDataType(new Object()));
+        Assert.assertFalse(UtilsInternalLimits.isSupportedDataType(new int[] { 1, 2 }));
+        Assert.assertFalse(UtilsInternalLimits.isSupportedDataType(null));
+    }
+
+    @Test
+    public void truncateValueSize() {
+        String value = "test";
+        int limit = 2;
+
+        String truncatedValue = UtilsInternalLimits.truncateValueSize(value, limit, new ModuleLog(), "tag");
+        Assert.assertEquals("te", truncatedValue);
+    }
+
+    @Test
+    public void truncateValueSize_null() {
+        String value = null;
+        int limit = 4;
+        ModuleLog spyLog = Mockito.spy(new ModuleLog());
+
+        String truncatedValue = UtilsInternalLimits.truncateValueSize(value, limit, spyLog, "tag");
+        Assert.assertNull(truncatedValue);
+        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateValueSize, value is null, returning");
+    }
+
+    @Test
+    public void truncateValueSize_empty() {
+        String value = "";
+        int limit = 4;
+        ModuleLog spyLog = Mockito.spy(new ModuleLog());
+
+        String truncatedValue = UtilsInternalLimits.truncateValueSize(value, limit, spyLog, "tag");
+        Assert.assertEquals("", truncatedValue);
+        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateValueSize, value is empty, returning");
+    }
+
+    @Test
+    public void truncateValueSize_multiple() {
+        String firstValue = "test_test";
+        String secondValue = "test";
+        int limit = 4;
+
+        String firstTruncatedValue = UtilsInternalLimits.truncateValueSize(firstValue, limit, new ModuleLog(), "tag");
+        String secondTruncatedValue = UtilsInternalLimits.truncateValueSize(secondValue, limit, new ModuleLog(), "tag");
+
+        Assert.assertEquals("test", firstTruncatedValue);
+        Assert.assertEquals(secondValue, secondTruncatedValue);
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation() {
+        Map<String, Object> segmentation = new ConcurrentHashMap<>();
+        segmentation.put("test_test", "value1");
+        segmentation.put("test", "value2");
+        segmentation.put("hobbit", 456789);
+        segmentation.put("map_to", 45.678f);
+        segmentation.put("map_too", TestUtils.map("a", 1));
+        segmentation.put("abcdefg", "12345");
+
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(5)
+            .setMaxValueSize(2)
+            .setMaxSegmentationValues(3);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+
+        Assert.assertEquals(3, segmentation.size());
+        Assert.assertEquals(456789, segmentation.get("hobbi"));
+        Assert.assertEquals("va", segmentation.get("test_"));
+        Assert.assertEquals(45.678f, segmentation.get("map_t"));
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation_removeUnsupportedDataTypes() {
+        Map<String, Object> segmentation = new ConcurrentHashMap<>();
+        segmentation.put("test_test", new int[] { 1, 2, 3 });
+        segmentation.put("test", new ArrayList<>());
+        segmentation.put("map_too", TestUtils.map("a", 1));
+
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(10)
+            .setMaxValueSize(10)
+            .setMaxSegmentationValues(10);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+
+        Assert.assertEquals(0, segmentation.size());
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation_clipSegmentationValues() {
+        Map<String, Object> segmentation = new ConcurrentHashMap<>();
+        segmentation.put("test_test", "value1");
+        segmentation.put("test", new ArrayList<>());
+        segmentation.put("map_too", TestUtils.map("a", 1));
+
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(20)
+            .setMaxValueSize(1)
+            .setMaxSegmentationValues(10);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+
+        Assert.assertEquals(1, segmentation.size());
+        Assert.assertEquals("v", segmentation.get("test_test"));
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation_null() {
+        Map<String, Object> segmentation = null;
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(5)
+            .setMaxValueSize(2)
+            .setMaxSegmentationValues(3);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+        Assert.assertNull(segmentation);
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation_empty() {
+        Map<String, Object> segmentation = new ConcurrentHashMap<>();
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(5)
+            .setMaxValueSize(2)
+            .setMaxSegmentationValues(3);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+        Assert.assertEquals(0, segmentation.size());
+    }
+
+    @Test
+    public void applySdkInternalLimitsToBreadcrumbs_valueSize() {
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits();
+        limitsConfig.setMaxBreadcrumbCount(3).setMaxValueSize(2);
+
+        List<String> breadcrumbs = new ArrayList<>();
+        breadcrumbs.add("test_test");
+        breadcrumbs.add("test");
+        breadcrumbs.add("hobbit");
+
+        UtilsInternalLimits.applyInternalLimitsToBreadcrumbs(breadcrumbs, limitsConfig, new ModuleLog(), "tag");
+        Assert.assertEquals(3, breadcrumbs.size());
+        Assert.assertEquals("te", breadcrumbs.get(0));
+        Assert.assertEquals("te", breadcrumbs.get(1));
+        Assert.assertEquals("ho", breadcrumbs.get(2));
+    }
+
+    @Test
+    public void applySdkInternalLimitsToBreadcrumb_breadcrumbCount() {
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits();
+        limitsConfig.setMaxBreadcrumbCount(3).setMaxValueSize(2);
+
+        List<String> breadcrumbs = new ArrayList<>();
+        breadcrumbs.add("mikasa");
+        breadcrumbs.add("eren");
+        breadcrumbs.add("jinwoo");
+        breadcrumbs.add("sung");
+        breadcrumbs.add("sasuke");
+        breadcrumbs.add("itachi");
+        breadcrumbs.add("madara");
+        breadcrumbs.add("jiraiya");
+
+        UtilsInternalLimits.applyInternalLimitsToBreadcrumbs(breadcrumbs, limitsConfig, new ModuleLog(), "tag");
+        Assert.assertEquals(3, breadcrumbs.size());
+        Assert.assertEquals("it", breadcrumbs.get(0));
+        Assert.assertEquals("ma", breadcrumbs.get(1));
+        Assert.assertEquals("ji", breadcrumbs.get(2));
     }
 }

--- a/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
@@ -42,7 +42,7 @@ public class UtilsInternalLimitsTests {
 
         String truncatedKey = UtilsInternalLimits.truncateKeyLength(key, limit, spyLog, "tag");
         Assert.assertNull(truncatedKey);
-        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateKeyLength, key is null, returning");
+        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateKeyLength, value is null, returning");
     }
 
     /**
@@ -59,7 +59,7 @@ public class UtilsInternalLimitsTests {
 
         String truncatedKey = UtilsInternalLimits.truncateKeyLength(key, limit, spyLog, "tag");
         Assert.assertEquals("", truncatedKey);
-        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateKeyLength, key is empty, returning");
+        Mockito.verify(spyLog, Mockito.times(1)).w("tag: [UtilsSdkInternalLimits] truncateKeyLength, value is empty, returning");
     }
 
     /**
@@ -385,5 +385,29 @@ public class UtilsInternalLimitsTests {
         Assert.assertEquals("12", segmentation.get("abcde"));
         Assert.assertEquals("va", segmentation.get("test_"));
         Assert.assertEquals(45.678f, segmentation.get("map_t"));
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation_null() {
+        Map<String, Object> segmentation = null;
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(5)
+            .setMaxValueSize(2)
+            .setMaxSegmentationValues(3);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+        Assert.assertNull(segmentation);
+    }
+
+    @Test
+    public void applySdkInternalLimitsToSegmentation_empty() {
+        Map<String, Object> segmentation = new ConcurrentHashMap<>();
+        ConfigSdkInternalLimits limitsConfig = new ConfigSdkInternalLimits()
+            .setMaxKeyLength(5)
+            .setMaxValueSize(2)
+            .setMaxSegmentationValues(3);
+
+        UtilsInternalLimits.applySdkInternalLimitsToSegmentation(segmentation, limitsConfig, new ModuleLog(), "tag");
+        Assert.assertEquals(0, segmentation.size());
     }
 }

--- a/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/UtilsInternalLimitsTests.java
@@ -384,7 +384,7 @@ public class UtilsInternalLimitsTests {
         Assert.assertEquals(3, segmentation.size());
         Assert.assertEquals("12", segmentation.get("abcde"));
         Assert.assertEquals("va", segmentation.get("test_"));
-        Assert.assertEquals(45.678f, segmentation.get("map_t"));
+        Assert.assertEquals(TestUtils.map("a", 1), segmentation.get("map_t"));
     }
 
     @Test

--- a/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
+++ b/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
@@ -749,7 +749,9 @@ public class CountlyStore implements StorageProvider, EventQueueProvider {
             tsStart = UtilsTime.getNanoTime();
         }
 
-        UtilsInternalLimits.removeUnsupportedDataTypes(segmentation);
+        if (segmentation != null) {
+            UtilsInternalLimits.removeUnsupportedDataTypes(segmentation);
+        }
 
         final Event event = new Event();
         event.key = key;

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleEvents.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleEvents.java
@@ -430,7 +430,9 @@ public class ModuleEvents extends ModuleBase implements EventProvider {
             synchronized (_cly) {
                 L.i("[Events] Calling recordEvent: [" + key + "]");
 
-                UtilsInternalLimits.truncateSegmentationValues(segmentation, _cly.config_.sdkInternalLimits.maxSegmentationValues, "[Events] recordEvent,", L);
+                if (segmentation != null) {
+                    UtilsInternalLimits.truncateSegmentationValues(segmentation, _cly.config_.sdkInternalLimits.maxSegmentationValues, "[Events] recordEvent,", L);
+                }
 
                 eventProvider.recordEventInternal(key, segmentation, count, sum, dur, null, null);
             }

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleViews.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleViews.java
@@ -162,7 +162,7 @@ public class ModuleViews extends ModuleBase implements ViewIdProvider {
         return viewSegmentation;
     }
 
-    void autoCloseRequiredViews(boolean closeAllViews, Map<String, Object> customViewSegmentation) {
+    void autoCloseRequiredViews(boolean closeAllViews, @Nullable Map<String, Object> customViewSegmentation) {
         L.d("[ModuleViews] autoCloseRequiredViews");
         List<String> viewsToRemove = new ArrayList<>(1);
 
@@ -175,6 +175,10 @@ public class ModuleViews extends ModuleBase implements ViewIdProvider {
 
         if (viewsToRemove.size() > 0) {
             L.d("[ModuleViews] autoCloseRequiredViews, about to close [" + viewsToRemove.size() + "] views");
+        }
+
+        if (customViewSegmentation == null) {
+            customViewSegmentation = new HashMap<>();
         }
 
         // todo: move to stopViewWithIDInternal?
@@ -207,6 +211,9 @@ public class ModuleViews extends ModuleBase implements ViewIdProvider {
         }
 
         // if segmentation is null this just returns so no null check necessary
+        if (customViewSegmentation == null) {
+            customViewSegmentation = new HashMap<>();
+        }
         UtilsInternalLimits.truncateSegmentationValues(customViewSegmentation, _cly.config_.sdkInternalLimits.maxSegmentationValues, "[ModuleViews] startViewInternal", L);
 
         UtilsInternalLimits.removeReservedKeysFromSegmentation(customViewSegmentation, reservedSegmentationKeysViews, "[ModuleViews] autoCloseRequiredViews, ", L);
@@ -294,6 +301,10 @@ public class ModuleViews extends ModuleBase implements ViewIdProvider {
 
         if (!consentProvider.getConsent(Countly.CountlyFeatureNames.views)) {
             return;
+        }
+
+        if (customViewSegmentation == null) {
+            customViewSegmentation = new HashMap<>();
         }
 
         // if segmentation is null this just returns so no null check necessary

--- a/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
@@ -62,6 +62,10 @@ public class UtilsInternalLimits {
     }
 
     private static String truncateString(@Nullable String value, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
+        assert limit >= 1;
+        assert tag != null;
+        assert L != null;
+
         if (value == null) {
             L.w(tag + ", value is null, returning");
             return value;
@@ -71,6 +75,8 @@ public class UtilsInternalLimits {
             L.w(tag + ", value is empty, returning");
             return value;
         }
+
+        assert value != null;
 
         if (value.length() > limit) {
             String truncatedValue = value.substring(0, limit);
@@ -90,6 +96,10 @@ public class UtilsInternalLimits {
      * @param <T> type of map value
      */
     protected static <T> void truncateSegmentationKeys(@Nullable Map<String, T> map, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
+        assert limit >= 1;
+        assert L != null;
+        assert tag != null;
+
         if (map == null) {
             L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, map is null, returning");
             return;
@@ -99,6 +109,8 @@ public class UtilsInternalLimits {
             L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, map is empty, returning");
             return;
         }
+
+        assert map != null;
 
         L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, map:[" + map + "]");
         // Replacing keys in a map is not safe, so we create a new map and put them after
@@ -123,6 +135,11 @@ public class UtilsInternalLimits {
     }
 
     protected static void truncateSegmentationKeysValues(@NonNull Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
+        assert segmentation != null;
+        assert limitsConfig != null;
+        assert L != null;
+        assert tag != null;
+
         L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, segmentation:[" + segmentation + "]");
         // Replacing keys in a map is not safe, so we create a new map and put them after
         Iterator<Map.Entry<String, Object>> iterator = segmentation.entrySet().iterator();
@@ -177,6 +194,8 @@ public class UtilsInternalLimits {
             L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is empty, returning");
             return;
         }
+
+        assert segmentation != null;
 
         truncateSegmentationKeysValues(segmentation, limitsConfig, L, tag);
         truncateSegmentationValues(segmentation, limitsConfig.maxSegmentationValues, tag, L);
@@ -237,6 +256,11 @@ public class UtilsInternalLimits {
             return;
         }
 
+        assert segmentation != null;
+        assert maxCount >= 1;
+        assert L != null;
+        assert messagePrefix != null;
+
         Iterator<Map.Entry<String, Object>> iterator = segmentation.entrySet().iterator();
         while (iterator.hasNext()) {
             if (segmentation.size() > maxCount) {
@@ -263,6 +287,11 @@ public class UtilsInternalLimits {
             return;
         }
 
+        assert segmentation != null;
+        assert reservedKeys != null;
+        assert L != null;
+        assert messagePrefix != null;
+
         for (String rKey : reservedKeys) {
             if (segmentation.containsKey(rKey)) {
                 L.w(messagePrefix + " provided segmentation contains protected key [" + rKey + "]");
@@ -281,6 +310,8 @@ public class UtilsInternalLimits {
         if (data == null) {
             return false;
         }
+
+        assert data != null;
 
         boolean removed = false;
 

--- a/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
@@ -122,38 +122,38 @@ public class UtilsInternalLimits {
         map.putAll(gonnaReplace);
     }
 
-    private static void truncateSegmentationKeysValues(@NonNull Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
+    protected static void truncateSegmentationKeysValues(@NonNull Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
         L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, segmentation:[" + segmentation + "]");
         // Replacing keys in a map is not safe, so we create a new map and put them after
+        Iterator<Map.Entry<String, Object>> iterator = segmentation.entrySet().iterator();
         Map<String, Object> gonnaReplace = new ConcurrentHashMap<>();
-        List<String> gonnaRemove = new ArrayList<>();
 
-        for (Map.Entry<String, Object> entry : segmentation.entrySet()) {
+        while (iterator.hasNext()) {
+            Map.Entry<String, Object> entry = iterator.next();
             String truncatedKey = truncateKeyLength(entry.getKey(), limitsConfig.maxKeyLength, L, tag);
             Object value = entry.getValue();
+
+            if (!isSupportedDataType(value)) {
+                iterator.remove();
+                continue;
+            }
+
             if (value instanceof String) {
                 value = truncateValueSize((String) value, limitsConfig.maxValueSize, L, tag);
             }
             if (!truncatedKey.equals(entry.getKey())) {
-                // add truncated key
-                gonnaReplace.put(truncatedKey, value);
-                // remove not truncated key
-                gonnaRemove.add(entry.getKey());
+                iterator.remove(); // Removes the current entry from the original map
+                gonnaReplace.put(truncatedKey, value); // Store the new entry to be replaced later
             } else if (value instanceof String && !value.equals(entry.getValue())) {
-                // update truncated value
-                segmentation.put(truncatedKey, value);
+                segmentation.put(truncatedKey, value); // Update value directly
             }
-        }
-
-        for (String key : gonnaRemove) {
-            segmentation.remove(key);
         }
 
         segmentation.putAll(gonnaReplace);
     }
 
     /**
-     * Applies following internal limits to the provided segmentation map:
+     * Removes unsupported data types and applies following internal limits to the provided segmentation map:
      * - max key length
      * - max value size
      * - max number of keys

--- a/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
@@ -153,7 +153,7 @@ public class UtilsInternalLimits {
     }
 
     /**
-     * This function removes unsupported data types then applies following internal limits to the provided segmentation map:
+     * Applies following internal limits to the provided segmentation map:
      * - max key length
      * - max value size
      * - max number of keys
@@ -174,7 +174,6 @@ public class UtilsInternalLimits {
             return;
         }
 
-        removeUnsupportedDataTypes(segmentation);
         truncateSegmentationValues(segmentation, limitsConfig.maxSegmentationValues, tag, L);
         truncateSegmentationKeysValues(segmentation, limitsConfig, L, tag);
     }

--- a/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
@@ -174,8 +174,8 @@ public class UtilsInternalLimits {
             return;
         }
 
-        truncateSegmentationValues(segmentation, limitsConfig.maxSegmentationValues, tag, L);
         truncateSegmentationKeysValues(segmentation, limitsConfig, L, tag);
+        truncateSegmentationValues(segmentation, limitsConfig.maxSegmentationValues, tag, L);
     }
 
     /**

--- a/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
@@ -36,22 +36,48 @@ public class UtilsInternalLimits {
      * @return truncated key
      */
     protected static String truncateKeyLength(@Nullable String key, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
-        if (key == null) {
-            L.w(tag + ": [UtilsSdkInternalLimits] truncateKeyLength, key is null, returning");
-            return key;
+        return truncateString(key, limit, L, tag + ": [UtilsSdkInternalLimits] truncateKeyLength");
+    }
+
+    /**
+     * Limits the size of all values in our key-value pairs.
+     * "Value" fields include:
+     * <pre>
+     * - segmentation value in case of strings (for all features)
+     * - custom user property string value
+     * - user profile named key (username, email, etc) string values. Except the "picture" field, which has a limit of 4096 chars
+     * - custom user property modifier string values. For example, for modifiers like "push," "pull," "setOnce", etc.
+     * - breadcrumb text
+     * - manual feedback widget reporting fields (reported as an event)
+     * - rating widget response (reported as an event)
+     * </pre>
+     *
+     * @param value to truncate
+     * @param limit to truncate to
+     * @param L logger
+     * @return truncated key
+     */
+    protected static String truncateValueSize(@Nullable String value, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
+        return truncateString(value, limit, L, tag + ": [UtilsSdkInternalLimits] truncateValueSize");
+    }
+
+    private static String truncateString(@Nullable String value, final int limit, @NonNull ModuleLog L, @NonNull String tag) {
+        if (value == null) {
+            L.w(tag + ", value is null, returning");
+            return value;
         }
 
-        if (key.isEmpty()) {
-            L.w(tag + ": [UtilsSdkInternalLimits] truncateKeyLength, key is empty, returning");
-            return key;
+        if (value.isEmpty()) {
+            L.w(tag + ", value is empty, returning");
+            return value;
         }
 
-        if (key.length() > limit) {
-            String truncatedKey = key.substring(0, limit);
-            L.w(tag + ": [UtilsSdkInternalLimits] truncateKeyLength, Key length exceeds limit of " + limit + " characters. Truncating key to " + limit + " characters. Truncated to " + truncatedKey);
-            return truncatedKey;
+        if (value.length() > limit) {
+            String truncatedValue = value.substring(0, limit);
+            L.w(tag + ", Value length exceeds limit of " + limit + " characters. Truncating value to " + limit + " characters. Truncated to " + truncatedValue);
+            return truncatedValue;
         }
-        return key;
+        return value;
     }
 
     /**
@@ -94,6 +120,63 @@ public class UtilsInternalLimits {
         }
 
         map.putAll(gonnaReplace);
+    }
+
+    private static void truncateSegmentationKeysValues(@NonNull Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
+        L.w(tag + ": [UtilsSdkInternalLimits] truncateMapKeys, segmentation:[" + segmentation + "]");
+        // Replacing keys in a map is not safe, so we create a new map and put them after
+        Map<String, Object> gonnaReplace = new ConcurrentHashMap<>();
+        List<String> gonnaRemove = new ArrayList<>();
+
+        for (Map.Entry<String, Object> entry : segmentation.entrySet()) {
+            String truncatedKey = truncateKeyLength(entry.getKey(), limitsConfig.maxKeyLength, L, tag);
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                value = truncateValueSize((String) value, limitsConfig.maxValueSize, L, tag);
+            }
+            if (!truncatedKey.equals(entry.getKey())) {
+                // add truncated key
+                gonnaReplace.put(truncatedKey, value);
+                // remove not truncated key
+                gonnaRemove.add(entry.getKey());
+            } else if (value instanceof String && !value.equals(entry.getValue())) {
+                // update truncated value
+                segmentation.put(truncatedKey, value);
+            }
+        }
+
+        for (String key : gonnaRemove) {
+            segmentation.remove(key);
+        }
+
+        segmentation.putAll(gonnaReplace);
+    }
+
+    /**
+     * This function removes unsupported data types then applies following internal limits to the provided segmentation map:
+     * - max key length
+     * - max value size
+     * - max number of keys
+     *
+     * @param segmentation Map<String, Object> @Nullable - segmentation map to apply limits to
+     * @param limitsConfig ConfigSdkInternalLimits @NonNull - limits configuration
+     * @param L ModuleLog @NonNull - logger
+     * @param tag String @NonNull - tag to use in logs
+     */
+    protected static void applySdkInternalLimitsToSegmentation(@Nullable Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
+        if (segmentation == null) {
+            L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is null, returning");
+            return;
+        }
+
+        if (segmentation.isEmpty()) {
+            L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is empty, returning");
+            return;
+        }
+
+        removeUnsupportedDataTypes(segmentation);
+        truncateSegmentationValues(segmentation, limitsConfig.maxSegmentationValues, tag, L);
+        truncateSegmentationKeysValues(segmentation, limitsConfig, L, tag);
     }
 
     /**

--- a/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
@@ -180,15 +180,10 @@ public class UtilsInternalLimits {
      * @param L ModuleLog @NonNull - logger
      * @param tag String @NonNull - tag to use in logs
      */
-    protected static void applySdkInternalLimitsToSegmentation(@Nullable Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
+    protected static void applySdkInternalLimitsToSegmentation(@NonNull Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
         assert limitsConfig != null;
         assert L != null;
         assert tag != null;
-
-        if (segmentation == null) {
-            L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is null, returning");
-            return;
-        }
 
         if (segmentation.isEmpty()) {
             L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is empty, returning");
@@ -251,11 +246,7 @@ public class UtilsInternalLimits {
      * @param messagePrefix String @NonNull - name of the module this function was called
      * @param segmentation Map<String, Object> @Nullable- segmentation that will be checked
      */
-    static void truncateSegmentationValues(@Nullable final Map<String, Object> segmentation, final int maxCount, @NonNull final String messagePrefix, final @NonNull ModuleLog L) {
-        if (segmentation == null) {
-            return;
-        }
-
+    static void truncateSegmentationValues(@NonNull final Map<String, Object> segmentation, final int maxCount, @NonNull final String messagePrefix, final @NonNull ModuleLog L) {
         assert segmentation != null;
         assert maxCount >= 1;
         assert L != null;
@@ -282,11 +273,7 @@ public class UtilsInternalLimits {
      * @param messagePrefix
      * @param L
      */
-    static void removeReservedKeysFromSegmentation(@Nullable Map<String, Object> segmentation, @NonNull String[] reservedKeys, @NonNull String messagePrefix, @NonNull ModuleLog L) {
-        if (segmentation == null) {
-            return;
-        }
-
+    static void removeReservedKeysFromSegmentation(@NonNull Map<String, Object> segmentation, @NonNull String[] reservedKeys, @NonNull String messagePrefix, @NonNull ModuleLog L) {
         assert segmentation != null;
         assert reservedKeys != null;
         assert L != null;
@@ -306,11 +293,7 @@ public class UtilsInternalLimits {
      * @param data
      * @return returns true if any entry had been removed
      */
-    static boolean removeUnsupportedDataTypes(Map<String, Object> data) {
-        if (data == null) {
-            return false;
-        }
-
+    static boolean removeUnsupportedDataTypes(@NonNull Map<String, Object> data) {
         assert data != null;
 
         boolean removed = false;
@@ -334,7 +317,7 @@ public class UtilsInternalLimits {
         return removed;
     }
 
-    static boolean isSupportedDataType(Object value) {
+    static boolean isSupportedDataType(@Nullable Object value) {
         return value instanceof String || value instanceof Integer || value instanceof Double || value instanceof Boolean || value instanceof Float;
     }
 }

--- a/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
+++ b/sdk/src/main/java/ly/count/android/sdk/UtilsInternalLimits.java
@@ -164,6 +164,10 @@ public class UtilsInternalLimits {
      * @param tag String @NonNull - tag to use in logs
      */
     protected static void applySdkInternalLimitsToSegmentation(@Nullable Map<String, Object> segmentation, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
+        assert limitsConfig != null;
+        assert L != null;
+        assert tag != null;
+
         if (segmentation == null) {
             L.w(tag + ": [UtilsSdkInternalLimits] applySdkInternalLimitsToSegmentation, map is null, returning");
             return;
@@ -176,6 +180,47 @@ public class UtilsInternalLimits {
 
         truncateSegmentationKeysValues(segmentation, limitsConfig, L, tag);
         truncateSegmentationValues(segmentation, limitsConfig.maxSegmentationValues, tag, L);
+    }
+
+    /**
+     * Applies the following internal limits to the provided breadcrumbs:
+     * - max value size
+     * - max number of breadcrumbs
+     *
+     * @param breadcrumbs List<String> @NonNull - breadcrumbs to apply limits to
+     * @param limitsConfig ConfigSdkInternalLimits @NonNull - limits configuration
+     * @param L ModuleLog @NonNull - logger
+     * @param tag String @NonNull - tag to use in logs
+     */
+    static void applyInternalLimitsToBreadcrumbs(@NonNull List<String> breadcrumbs, @NonNull ConfigSdkInternalLimits limitsConfig, @NonNull ModuleLog L, @NonNull String tag) {
+        assert breadcrumbs != null;
+        assert limitsConfig != null;
+        assert L != null;
+        assert tag != null;
+
+        if (breadcrumbs.isEmpty()) {
+            L.w(tag + ": [UtilsSdkInternalLimits] applyInternalLimitsToBreadcrumbs, breadcrumbs is empty, returning");
+            return;
+        }
+
+        Iterator<String> iterator = breadcrumbs.iterator();
+        while (iterator.hasNext()) {
+            if (breadcrumbs.size() > limitsConfig.maxBreadcrumbCount) {
+                String breadcrumb = iterator.next();
+                L.w(tag + ": [UtilsSdkInternalLimits] applyInternalLimitsToBreadcrumbs, breadcrumb:[" + breadcrumb + "]");
+                iterator.remove();
+            } else {
+                break;
+            }
+        }
+
+        for (int i = 0; i < breadcrumbs.size(); i++) {
+            String breadcrumb = breadcrumbs.get(i);
+            String truncatedBreadcrumb = truncateValueSize(breadcrumb, limitsConfig.maxValueSize, L, tag);
+            if (!truncatedBreadcrumb.equals(breadcrumb)) {
+                breadcrumbs.set(i, truncatedBreadcrumb);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Added two new internal limits utils func and their related tests
- truncateValueSize
- applySdkInternalLimitsToSegmentation
    -Removes unsupported data types and applies following internal limits to the provided segmentation map:
     - max key length
     - max value size
     - max number of keys

Created a "truncateString" function to be used with "truncateKeyLength" and "truncateValueSize"