### PR TITLE
Delete unnecessary "removeUnsupportedDataTypes"

### DIFF
--- a/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
+++ b/sdk/src/main/java/ly/count/android/sdk/CountlyStore.java
@@ -749,10 +749,6 @@ public class CountlyStore implements StorageProvider, EventQueueProvider {
             tsStart = UtilsTime.getNanoTime();
         }
 
-        if (segmentation != null) {
-            UtilsInternalLimits.removeUnsupportedDataTypes(segmentation);
-        }
-
         final Event event = new Event();
         event.key = key;
         event.segmentation = segmentation;

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleEvents.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleEvents.java
@@ -159,6 +159,9 @@ public class ModuleEvents extends ModuleBase implements EventProvider {
                 break;
             case ACTION_EVENT_KEY:
                 if (consentProvider.getConsent(Countly.CountlyFeatureNames.clicks) || consentProvider.getConsent(Countly.CountlyFeatureNames.scrolls)) {
+                    if (segmentation != null) {
+                        UtilsInternalLimits.removeUnsupportedDataTypes(segmentation);
+                    }
                     eventQueueProvider.recordEventToEventQueue(key, segmentation, count, sum, dur, timestamp, hour, dow, eventId, pvid, cvid, null);
                     _cly.moduleRequestQueue.sendEventsIfNeeded(false);
                 }

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleFeedback.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleFeedback.java
@@ -3,7 +3,6 @@ package ly.count.android.sdk;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.webkit.WebView;
@@ -448,6 +447,8 @@ public class ModuleFeedback extends ModuleBase {
 
         if (widgetResult != null) {
             //removing broken values first
+            UtilsInternalLimits.removeUnsupportedDataTypes(widgetResult);
+
             Iterator<Map.Entry<String, Object>> iter = widgetResult.entrySet().iterator();
             while (iter.hasNext()) {
                 Map.Entry<String, Object> entry = iter.next();


### PR DESCRIPTION
Function call is unnecessary, because it has already called before coming to the that step on the recordEvent flow. 

I have added the call to the not-used two places to protect logic.
This will prevent looping through segmentations two times.