### PR TITLE
Native crash truncation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## X.X.X
+* Mitigated an issue where a native crash dump was truncated by the stack trace line length limit when a global crash filter was set.
+
 ## 26.1.3
 * Added gradle configuration cache support to upload symbols plugin.
 * Improved user properties auto-save conditions to flush event queue with every user property call.

--- a/sdk/src/androidTest/java/ly/count/android/sdk/ModuleCrashTests.java
+++ b/sdk/src/androidTest/java/ly/count/android/sdk/ModuleCrashTests.java
@@ -802,6 +802,33 @@ public class ModuleCrashTests {
     }
 
     /**
+     * A native crash dump is a single-line base64 string. When a global crash filter is set,
+     * the SDK must NOT apply the per-line stack trace length limit (maxStackTraceLineLength) to it,
+     * otherwise the whole dump is truncated to 'maxStackTraceLineLength' characters and corrupted.
+     * Regression test: the queued "_error" must equal the full, untruncated base64 dump.
+     */
+    @Test
+    public void recordException_globalCrashFilter_nativeCrash_notTruncatedByLineLength() throws JSONException {
+        TestUtils.getCountlyStore().clear();
+        String finalPath = TestUtils.getContext().getCacheDir().getAbsolutePath() + File.separator + "Countly" + File.separator + "CrashDumps";
+
+        // payload whose base64 length far exceeds the default maxStackTraceLineLength (200)
+        char[] payload = new char[400];
+        Arrays.fill(payload, 'a');
+        String longDump = new String(payload);
+        createFile(finalPath, File.separator + "dumpLong.dmp", longDump);
+
+        CountlyConfig cConfig = TestUtils.createBaseConfig();
+        cConfig.metricProviderOverride = mmp;
+        cConfig.crashes.setGlobalCrashFilterCallback(crash -> false); // keep the crash, do not modify it
+
+        new Countly().init(cConfig);
+
+        Assert.assertEquals(1, TestUtils.getCurrentRQ().length);
+        validateCrash(extractNativeCrash(longDump), "", true, true, new ConcurrentHashMap<>(), 0, new ConcurrentHashMap<>(), new ArrayList<>());
+    }
+
+    /**
      * Validate that deprecated crash filter, filters out all native crash dumps
      * Validate RQ is empty after initialization of the SDK
      */

--- a/sdk/src/main/java/ly/count/android/sdk/ModuleCrash.java
+++ b/sdk/src/main/java/ly/count/android/sdk/ModuleCrash.java
@@ -123,7 +123,7 @@ public class ModuleCrash extends ModuleBase {
         String dumpString = Base64.encodeToString(bytes, Base64.NO_WRAP);
 
         CrashData crashData = prepareCrashData(dumpString, false, true, null);
-        if (!crashFilterCheck(crashData)) {
+        if (!crashFilterCheck(crashData, true)) {
             sendCrashReportToQueue(crashData, true);
         }
     }
@@ -209,7 +209,7 @@ public class ModuleCrash extends ModuleBase {
 
                     String stackTrace = prepareStackTrace(e);
                     CrashData crashData = prepareCrashData(stackTrace, false, false, null);
-                    if (!crashFilterCheck(crashData)) {
+                    if (!crashFilterCheck(crashData, false)) {
                         sendCrashReportToQueue(crashData, false);
                     }
                 }
@@ -230,9 +230,10 @@ public class ModuleCrash extends ModuleBase {
      * If it does, the crash should be ignored
      *
      * @param crashData CrashData object to check
+     * @param isNativeCrash whether the crash is a native crash dump (base64 string, not a Java stack trace)
      * @return true if a match was found
      */
-    boolean crashFilterCheck(@NonNull CrashData crashData) {
+    boolean crashFilterCheck(@NonNull CrashData crashData, final boolean isNativeCrash) {
         assert crashData != null;
 
         L.d("[ModuleCrash] Calling crashFilterCheck");
@@ -254,8 +255,12 @@ public class ModuleCrash extends ModuleBase {
 
         UtilsInternalLimits.applyInternalLimitsToBreadcrumbs(crashData.getBreadcrumbs(), _cly.config_.sdkInternalLimits, L, "[ModuleCrash] sendCrashReportToQueue");
         UtilsInternalLimits.applySdkInternalLimitsToSegmentation(crashData.getCrashSegmentation(), _cly.config_.sdkInternalLimits, L, "[ModuleCrash] sendCrashReportToQueue");
-        String truncatedStackTrace = UtilsInternalLimits.applyInternalLimitsToStackTraces(crashData.getStackTrace(), _cly.config_.sdkInternalLimits.maxStackTraceLineLength, "[ModuleCrash] sendCrashReportToQueue", L);
-        crashData.setStackTrace(truncatedStackTrace);
+        // Stack trace line limits must not be applied to native crashes: the "stack trace" of a
+        // native crash is a single-line base64 dump, so per-line truncation would corrupt the dump.
+        if (!isNativeCrash) {
+            String truncatedStackTrace = UtilsInternalLimits.applyInternalLimitsToStackTraces(crashData.getStackTrace(), _cly.config_.sdkInternalLimits.maxStackTraceLineLength, "[ModuleCrash] sendCrashReportToQueue", L);
+            crashData.setStackTrace(truncatedStackTrace);
+        }
         UtilsInternalLimits.removeUnsupportedDataTypes(crashData.getCrashSegmentation(), L);
         UtilsInternalLimits.removeUnsupportedDataTypes(crashData.getCrashMetrics(), L);
 
@@ -318,7 +323,7 @@ public class ModuleCrash extends ModuleBase {
         String exceptionString = prepareStackTrace(exception);
 
         CrashData crashData = prepareCrashData(exceptionString, itIsHandled, false, customSegmentation);
-        if (crashFilterCheck(crashData)) {
+        if (crashFilterCheck(crashData, false)) {
             L.d("[ModuleCrash] Crash filter found a match, exception will be ignored, [" + exceptionString.substring(0, Math.min(exceptionString.length(), 60)) + "]");
         } else {
             sendCrashReportToQueue(crashData, false);


### PR DESCRIPTION
Internal limit was applied on base64 singleline dump when crash filter was used preventing server to walk the stacktrace